### PR TITLE
small voice compass changes

### DIFF
--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -96,7 +96,7 @@ export const create = (config: Config): VoiceCompass => {
       })
       .catch((err: Error) => {
         if (config.debug) {
-          console.error(`× step: ${payload.stepId}`, err);
+          console.error(`× step: ${payload.stepId}`, err, payload);
         }
         return {
           error: `Something went wrong`,

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -23,10 +23,21 @@ export interface Config {
 
 export interface StepData {
   stepId: string;
-  context?: Record<string, any>;
+  context?: Context;
 }
 
-export type Context = Record<string, any>;
+/** A JSON stringify-able value. */
+export type jsonable =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | jsonable[]
+  | { [key: string]: jsonable }
+  | { toJSON(): jsonable };
+
+export type Context = Record<string, jsonable>;
 
 // The journey manager object
 export interface VoiceCompass {

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -87,12 +87,12 @@ export const create = (config: Config): VoiceCompass => {
       },
       body: JSON.stringify(payload),
     })
-      .then((res) => res.json())
-      .then((res: StepUpdate) => {
+      .then(() => {
         if (config.debug) {
           console.info(`✓ step: ${payload.stepId}`, payload);
         }
-        return res;
+
+        return {};
       })
       .catch((err: Error) => {
         if (config.debug) {

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -90,19 +90,13 @@ export const create = (config: Config): VoiceCompass => {
       .then((res) => res.json())
       .then((res: StepUpdate) => {
         if (config.debug) {
-          console.info(
-            `${String.fromCodePoint(0x02713)} step: ${payload.stepId}`,
-            payload,
-          );
+          console.info(`✓ step: ${payload.stepId}`, payload);
         }
         return res;
       })
       .catch((err: Error) => {
         if (config.debug) {
-          console.error(
-            `${String.fromCodePoint(0x000d7)} step: ${payload.stepId}`,
-            err,
-          );
+          console.error(`× step: ${payload.stepId}`, err);
         }
         return {
           error: `Something went wrong`,

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -41,7 +41,6 @@ export interface Update {
 }
 
 export interface StepUpdate {
-  error?: string;
   warning?: string;
 }
 
@@ -98,9 +97,7 @@ export const create = (config: Config): VoiceCompass => {
         if (config.debug) {
           console.error(`× step: ${payload.stepId}`, err, payload);
         }
-        return {
-          error: `Something went wrong`,
-        };
+        throw err;
       });
   };
 

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -21,7 +21,7 @@ export interface Config {
 }
 
 export interface StepData {
-  stepId?: string;
+  stepId: string;
   context?: Record<string, any>;
 }
 
@@ -119,8 +119,7 @@ export const create = (config: Config): VoiceCompass => {
       });
     }
     lastUpdate = {
-      // TODO: sort out whether optional stepID's are even allowed
-      stepId: stepData.stepId || "",
+      stepId: stepData.stepId,
       journeyId: currentJourneyId,
       context: stepData.context,
     };

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -23,21 +23,10 @@ export interface Config {
 
 export interface StepData {
   stepId: string;
-  context?: Context;
+  context?: Record<string, any>;
 }
 
-/** A JSON stringify-able value. */
-export type jsonable =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | jsonable[]
-  | { [key: string]: jsonable }
-  | { toJSON(): jsonable };
-
-export type Context = Record<string, jsonable>;
+export type Context = Record<string, any>;
 
 // The journey manager object
 export interface VoiceCompass {

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -104,7 +104,14 @@ export const create = (config: Config): VoiceCompass => {
       });
   };
 
+  // uuid v4 regex
+  const stepIdRegex =
+    /^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
   const sendStep = (stepId: string, context?: Context) => {
+    if (!stepIdRegex.test(stepId)) {
+      throw new Error("Invalid stepId. It should be formatted as a UUID.");
+    }
+
     const stepData: StepData = {
       stepId,
       context,

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -17,7 +17,7 @@ export interface Config {
   preventRepeats?: boolean;
   onSessionUpdate?: (session: Session) => void;
   debug?: boolean;
-  dev?: boolean;
+  apiUrl?: string;
 }
 
 export interface StepData {
@@ -45,10 +45,6 @@ export interface StepUpdate {
   warning?: string;
 }
 
-const devApiUrl = "https://dev.mm.nlx.ai";
-
-const prodApiUrl = "https://mm.nlx.ai";
-
 export const create = (config: Config): VoiceCompass => {
   const conversationId = config.conversationId;
 
@@ -58,7 +54,7 @@ export const create = (config: Config): VoiceCompass => {
     );
   }
 
-  const apiUrl = config.dev ? devApiUrl : prodApiUrl;
+  const apiUrl = config.apiUrl ?? "https://mm.nlx.ai";
 
   let lastUpdate: Update | null = null;
 

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -16,6 +16,7 @@ export interface Config {
   languageCode: string;
   preventRepeats?: boolean;
   onSessionUpdate?: (session: Session) => void;
+  lastUpdate?: Update;
   debug?: boolean;
   apiUrl?: string;
 }
@@ -55,7 +56,7 @@ export const create = (config: Config): VoiceCompass => {
 
   const apiUrl = config.apiUrl ?? "https://mm.nlx.ai";
 
-  let lastUpdate: Update | null = null;
+  let lastUpdate: Update | null = config.lastUpdate ?? null;
 
   let currentJourneyId: string = config.journeyId;
 
@@ -68,7 +69,8 @@ export const create = (config: Config): VoiceCompass => {
     });
   };
 
-  saveSession();
+  // initialize session if we're not recovering an existing session
+  if (!lastUpdate) saveSession();
 
   const sendUpdateRequest = (stepData: StepData): Promise<StepUpdate> => {
     const payload = {

--- a/packages/voice-compass/tsconfig.json
+++ b/packages/voice-compass/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "esnext",
+    "moduleResolution": "bundler",
     "declaration": true,
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
a handful of small changes to the voice compass API. Want to sync with @sam-trost about these

These are all good, but talking to Sam, I'd like to try scrapping most of this API and making it much much simpler. 

from my understanding: Voice Compass used to model a state machine internally, but now requires the user to model the state machine. Considering that: I think the small complexity around state management can go away and can be modeled in the documentation. So while this PR is probably a bunch of baby steps in the right direction, the subsequent PR will try trimming the library down to the bare minimum