### PR TITLE
fix codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @peterszerzo
-* @jakub-nlx
+* @jakub-nlx @peterszerzo


### PR DESCRIPTION
I believe previously, @jakub-nlx code ownership was _overwriting_ @peterszerzo because it was later in the file. This single rule should put them at equal precedence. (follow up to #19, h/t @sam-trost  )

My understanding is that last-wins in code-owners file but each rule can have multiple users. see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file