### PR TITLE
Add semicolon to message check script in chat widget

### DIFF
--- a/packages/website/src/snippets.ts
+++ b/packages/website/src/snippets.ts
@@ -129,7 +129,7 @@ onExpand: (conversationHandler) => {
       conversationHandler.sendWelcomeIntent();
     }
     conversationHandler.unsubscribe(checkMessages);
-  }
+  };
   conversationHandler.subscribe(checkMessages);
 },
 // CUSTOM BEHAVIOR SNIPPET END`,


### PR DESCRIPTION
Need to add this semicolon so that if the customer puts the script in one line, the javascript interpreter doesn't get weird.

@michaelglass @jakub-nlx merging this right away because it is urgent for a user.