### PR TITLE
support browser router on github pages

### DIFF
--- a/packages/website/404.html
+++ b/packages/website/404.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>NLX | Developers</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -26,6 +26,29 @@
       sizes="192x192"
       href="./favicon192x192.png"
     />
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+
     <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && cp 404.html dist/404.html",
     "dev": "vite --force",
     "lint:check": "eslint src/ --ext .ts,.tsx,.js,.jsx,.mdx",
     "lint": "eslint src/ --ext .ts,.tsx,.js,.jsx,.mdx --fix",

--- a/packages/website/src/main.tsx
+++ b/packages/website/src/main.tsx
@@ -1,7 +1,7 @@
 import React, { type FC, useState } from "react";
 import "./index.css";
 import { createRoot } from "react-dom/client";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { Header } from "./components/Header";
 import { Hero } from "./components/Hero";
 import { Nav, MobileNav } from "./components/Nav";
@@ -37,7 +37,7 @@ const App: FC<{}> = () => {
 };
 
 createRoot(document.getElementById("app") as Element).render(
-  <HashRouter>
+  <BrowserRouter>
     <App />
-  </HashRouter>,
+  </BrowserRouter>,
 );


### PR DESCRIPTION
mislead by dev environment differing from prod environment.

Github Actions doesn't rewrite URLs on refresh, so using BrowserRouter meant loading, e.g. `/foo` would just 404.

This PR
- adds a custom 404.html that redirects folks back to `/index` with the path in the query string
- adds some logic to index.html that parses the parses the path out of the query string. 
- adds a caddy dev environment that should mimick github actions

I feel mixed about this PR. On the one hand, I think BrowserRouter produces prettier URLs and most importantly, those URLs support on-page anchor tags (needed for #31 ) But on the other hand, this PR is a bit of a hack and abuses the 404 page.

other solutions:
- static rendering (might help with SEO, e.g. right now google doesn't have any deep links into https://developers.nlx.ai/)
- from @peterszerzo on `npm run build`, copy `index.html` to all routes in `dist/`