### PR TITLE
Allow choice reselection option for chat widget

### DIFF
--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -242,9 +242,9 @@ export const createConversation = (config: Config): ConversationHandler => {
       ...state,
       ...change,
     };
-    subscribers.forEach((subscriber) =>
-      { subscriber(fromInternal(state), newResponse); },
-    );
+    subscribers.forEach((subscriber) => {
+      subscriber(fromInternal(state), newResponse);
+    });
   };
 
   // initial eslint integration
@@ -369,7 +369,7 @@ export const createConversation = (config: Config): ConversationHandler => {
         .catch((err) => {
           console.warn(err);
           failureHandler();
-        }); 
+        });
     }
   };
 
@@ -447,8 +447,8 @@ export const createConversation = (config: Config): ConversationHandler => {
   const appendStructuredUserResponse = (
     structured: StructuredRequest,
     context?: Context,
-  // initial eslint integration
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    // initial eslint integration
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   ) => {
     const newResponse: Response = {
       type: "user",
@@ -561,12 +561,8 @@ export const createConversation = (config: Config): ConversationHandler => {
       sendIntent(welcomeIntent, context);
     },
     sendChoice: (choiceId, context) => {
-      // initial eslint integration
-      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-      const containsChoice = (botMessage: BotMessage) =>
-        // initial eslint integration
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        (botMessage.choices || [])
+      const containsChoice = (botMessage: BotMessage): boolean =>
+        (botMessage.choices ?? [])
           .map((choice) => choice.choiceId)
           .includes(choiceId);
 
@@ -681,8 +677,8 @@ export function promisify<T>(
       const subscription = (
         _responses: Response[],
         newResponse: Response | undefined,
-      // initial eslint integration
-      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+        // initial eslint integration
+        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       ) => {
         // initial eslint integration
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/chat-widget/src/index.tsx
+++ b/packages/chat-widget/src/index.tsx
@@ -109,6 +109,7 @@ const MessageGroups: FC<{
   chat: ChatHook;
   children?: ReactNode;
   customModalities: Record<string, CustomModalityComponent>;
+  allowChoiceReselection?: boolean;
 }> = (props) => (
   <C.MessageGroups>
     {/* initial eslint integration */}
@@ -132,7 +133,8 @@ const MessageGroups: FC<{
                         {...(() => {
                           // initial eslint integration
                           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                          return botMessage.selectedChoiceId
+                          return !(props.allowChoiceReselection ?? false) &&
+                            botMessage.selectedChoiceId != null
                             ? {
                                 disabled: true,
                                 selected:
@@ -499,6 +501,7 @@ export const Widget = forwardRef<WidgetRef, Props>((props, ref) => {
                 <MessageGroups
                   chat={chat}
                   customModalities={props.customModalities ?? {}}
+                  allowChoiceReselection={props.allowChoiceReselection}
                 >
                   {chat.waiting && (
                     <C.MessageGroup>

--- a/packages/chat-widget/src/props.ts
+++ b/packages/chat-widget/src/props.ts
@@ -22,6 +22,7 @@ export interface Props {
   inputPlaceholder?: string;
   loaderMessage?: string;
   showLoaderMessageAfter?: number;
+  allowChoiceReselection?: boolean;
   storeIn?: StorageType;
   onExpand?: (conversationHandler: ConversationHandler) => void;
   onCollapse?: (conversationHandler: ConversationHandler) => void;


### PR DESCRIPTION
New widget configuration option to enable the behavior that does not disable choice buttons once a selection is made, allowing the selection to be changed later on.