### PR TITLE
Normalize slots dictionary as array

### DIFF
--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -148,7 +148,7 @@ interface BotRequest {
     unstructured?: {
       text: string;
     };
-    structured?: StructuredRequest;
+    structured?: StructuredRequest & { slots?: SlotValue[] };
   };
 }
 


### PR DESCRIPTION
While the frontend should support both arrays and objects for slots in terms of API, the backend should always be sent arrays.