### PR TITLE
document core chat api

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,10 @@
       devShells.default = pkgs.mkShell {
         packages = with pkgs; [
           (assertVersion (nixpkgs.lib.strings.fileContents "${self}/.node-version") nodejs_18)
-          # caddy is used to mimic github actions more closely than the vite dev server
+          # caddy is used to mimic github actions more closely than the vite dev server. Not used in production
           (assertVersion "2.7.6" caddy)
+          # comrak is used to preview rendered markdown. Not used in production.
+          (assertVersion "0.19.0" comrak)
         ];
       };
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18943,10 +18943,13 @@
         "@types/node": "^11.15.11",
         "@types/ramda": "0.29.1",
         "@types/uuid": "^9.0.7",
+        "concat-md": "^0.5.1",
         "eslint-config-nlx": "*",
         "prettier": "^3.1.0",
         "rollup": "^4.9.3",
         "rollup-plugin-node-polyfills": "^0.2.1",
+        "typedoc": "^0.25.13",
+        "typedoc-plugin-markdown": "^3.17.1",
         "typescript": "^5.2.2"
       }
     },

--- a/packages/chat-core/.eslintrc.cjs
+++ b/packages/chat-core/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /** @type {import('eslint').Linter.Config } */
 module.exports = {
   root: true,
-  extends: ["nlx"],
+  extends: ["nlx", "nlx/documentation"],
 };

--- a/packages/chat-core/.gitignore
+++ b/packages/chat-core/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .env
 dist
 lib
+docs

--- a/packages/chat-core/README.md
+++ b/packages/chat-core/README.md
@@ -1,6 +1,6 @@
 # NLX Chat SDK Core
 
-This is the core package of our official JavaScript SDK to communicate with NLX conversational bots.
+The core package of our official JavaScript SDK to communicate with NLX conversational bots.
 
 ## Getting started
 

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -9,9 +9,11 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "rm -rf lib && rollup -c",
+    "docs": "typedoc",
     "lint:check": "eslint src/ --ext .ts,.tsx,.js,.jsx",
     "lint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix",
     "prepublish": "npm run build",
+    "publish-docs": "npm run docs && concat-md --decrease-title-levels --dir-name-as-title docs/ > ../website/src/content/05-02-headless-api-reference.md",
     "tsc": "tsc"
   },
   "author": "Peter Szerzo <peter@nlx.ai>",
@@ -27,10 +29,13 @@
     "@types/node": "^11.15.11",
     "@types/ramda": "0.29.1",
     "@types/uuid": "^9.0.7",
+    "concat-md": "^0.5.1",
     "eslint-config-nlx": "*",
     "prettier": "^3.1.0",
     "rollup": "^4.9.3",
     "rollup-plugin-node-polyfills": "^0.2.1",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-markdown": "^3.17.1",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -9,11 +9,12 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "rm -rf lib && rollup -c",
-    "docs": "typedoc",
+    "docs": "rm -rf docs/ && typedoc && concat-md --decrease-title-levels --dir-name-as-title docs/ > docs/index.md",
     "lint:check": "eslint src/ --ext .ts,.tsx,.js,.jsx",
     "lint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix",
     "prepublish": "npm run build",
-    "publish-docs": "npm run docs && concat-md --decrease-title-levels --dir-name-as-title docs/ > ../website/src/content/05-02-headless-api-reference.md",
+    "preview-docs": "npm run docs && comrak --unsafe --gfm -o docs/index.html docs/index.md && open docs/index.html",
+    "publish-docs": "npm run docs && mv docs/index.md ../website/src/content/05-02-headless-api-reference.md",
     "tsc": "tsc"
   },
   "author": "Peter Szerzo <peter@nlx.ai>",

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -301,7 +301,7 @@ export interface Config {
    */
   conversationId?: string;
   /**
-   * TODO I don't know what this is
+   * Setting the `userID` allows it to be searchable in bot history, as well as usable via `{System.userId}` in the intent.
    */
   userId?: string;
   /**
@@ -954,7 +954,6 @@ export function promisify<T>(
   return async (payload: T) => {
     return await new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        // TODO should this unsubscribe?
         reject(new Error("The request timed out."));
       }, timeout);
       const subscription = (

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -4,510 +4,15 @@ import { equals, adjust, omit } from "ramda";
 import { v4 as uuid } from "uuid";
 import packageJson from "../package.json";
 
-// Bot response
-
 /**
- * Context to send back to the bot, for usage later in the intent.
+ * Call this to create a conversation handler.
+ *
+ * @param config -
+ * @returns The {@link ConversationHandler} is a bundle of functions to interact with the conversation.
  */
-export type Context = Record<string, any>;
-
-/**
- * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
- *
- * An array of `SlotValue` objects is equivalent to a {@link SlotsRecord}.
- */
-export interface SlotValue {
-  /**
-   * The attached slot's name
-   */
-  slotId: string;
-  /**
-   * Usually this will be a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
-   * for custom slots, this can optionally be the value's ID.
-   */
-  value: any;
-}
-
-/**
- * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
- *
- * `SlotRecord` Keys are the attached slot's name
- *
- * `SlotRecord` Values are usually a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
- * for custom slots, this can optionally be the value's ID.
- *
- * A `SlotsRecord` is equivalent to an array of {@link SlotValue} objects.
- */
-export type SlotsRecord = Record<string, any>;
-
-/**
- * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
- *
- * Supports either a {@link SlotsRecord} or an array of {@link SlotValue} objects
- */
-export type SlotsRecordOrArray = SlotsRecord | SlotValue[];
-
-/**
- * A message from the bot
- *
- * See also:
- * - {@link UserResponse}
- * - {@link FailureMessage}
- * - {@link Response}
- */
-export interface BotResponse {
-  /**
-   * The type of the response is `"bot"` for bot and `"user"` for user.
-   */
-  type: "bot";
-  /**
-   * When the response was received
-   */
-  receivedAt: Time;
-  /**
-   * The payload of the response
-   */
-  payload: BotResponsePayload;
-}
-
-/**
- *
- */
-export interface BotResponsePayload {
-  /**
-   *
-   */
-  expirationTimestamp?: number;
-  /**
-   *
-   */
-  conversationId?: string;
-  /**
-   *
-   */
-  messages: BotMessage[];
-  /**
-   *
-   */
-  metadata?: BotResponseMetadata;
-  /**
-   *
-   */
-  payload?: string;
-  /**
-   *
-   */
-  modalities?: Record<string, any>;
-  /**
-   *
-   */
-  context?: Context;
-}
-
-/**
- *
- */
-export interface BotResponseMetadata {
-  /**
-   *
-   */
-  intentId?: string;
-  /**
-   *
-   */
-  escalation?: boolean;
-  /**
-   *
-   */
-  frustration?: boolean;
-  /**
-   *
-   */
-  incomprehension?: boolean;
-  /**
-   *
-   */
-  hasPendingDataRequest?: boolean;
-}
-
-/**
- *
- */
-export interface BotMessage {
-  /**
-   *
-   */
-  messageId?: string;
-  /**
-   *
-   */
-  nodeId?: string;
-  /**
-   *
-   */
-  text: string;
-  /**
-   *
-   */
-  choices: Choice[];
-  /**
-   *
-   */
-  selectedChoiceId?: string;
-}
-
-/**
- *
- */
-export interface Choice {
-  /**
-   *
-   */
-  choiceId: string;
-  /**
-   *
-   */
-  choiceText: string;
-  /**
-   *
-   */
-  choicePayload?: string;
-}
-
-// User message
-
-/**
- *
- */
-export interface UserResponse {
-  /**
-   * The type of the response is `"bot"` for bot and `"user"` for user.
-   */
-  type: "user";
-  /**
-   *
-   */
-  receivedAt: Time;
-  /**
-   *
-   */
-  payload: UserResponsePayload;
-}
-
-/**
- *
- */
-export type UserResponsePayload =
-  | {
-      /**
-       *
-       */
-      type: "text";
-      /**
-       *
-       */
-      text: string;
-      /**
-       *
-       */
-      context?: Context;
-    }
-  | {
-      /**
-       *
-       */
-      type: "choice";
-      /**
-       *
-       */
-      choiceId: string;
-      /**
-       *
-       */
-      context?: Context;
-    }
-  | ({
-      /**
-       *
-       */
-      type: "structured";
-      /**
-       *
-       */
-      context?: Context;
-    } & StructuredRequest);
-
-// Failure message
-
-/**
- *
- */
-export interface FailureMessage {
-  /**
-   *
-   */
-  type: "failure";
-  /**
-   *
-   */
-  payload: {
-    /**
-     *
-     */
-    text: string;
-  };
-  /**
-   *
-   */
-  receivedAt: Time;
-}
-
-/**
- *
- */
-export type Response = BotResponse | UserResponse | FailureMessage;
-
-/**
- *
- */
-export type Time = number;
-
-// Config and state
-
-/**
- *
- */
-export type Environment = "production" | "development";
-
-/**
- *
- */
-export interface Config {
-  /**
-   *
-   */
-  botUrl: string;
-  /**
-   *
-   */
-  conversationId?: string;
-  /**
-   *
-   */
-  userId?: string;
-  /**
-   *
-   */
-  responses?: Response[];
-  /**
-   *
-   */
-  failureMessage?: string;
-  /**
-   *
-   */
-  environment?: Environment;
-  /**
-   *
-   */
-  headers: Record<string, string> & { "nlx-api-key": string };
-  /**
-   *
-   */
-  languageCode: string;
-  // Experimental settings
-  /**
-   *
-   */
-  experimental?: {
-    // Simulate alternative channel types
-    /**
-     *
-     */
-    channelType?: string;
-    // Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio
-    /**
-     *
-     */
-    completeBotUrl?: boolean;
-  };
-}
-
-const welcomeIntent = "NLX.Welcome";
-
-const defaultFailureMessage = "We encountered an issue. Please try again soon.";
-
-/**
- *
- */
-export type State = Response[];
-
-const normalizeSlots = (
-  slotsRecordOrArray: SlotsRecordOrArray,
-): SlotValue[] => {
-  if (Array.isArray(slotsRecordOrArray)) {
-    return slotsRecordOrArray;
-  }
-  return Object.entries(slotsRecordOrArray).map(([key, value]) => ({
-    slotId: key,
-    value,
-  }));
-};
-
-/**
- *
- */
-export interface StructuredRequest {
-  /**
-   *
-   */
-  choiceId?: string;
-  /**
-   *
-   */
-  intentId?: string;
-  /**
-   *
-   */
-  nodeId?: string;
-  /**
-   *
-   */
-  slots?: SlotsRecordOrArray;
-  /**
-   *
-   */
-  poll?: boolean;
-}
-
-interface BotRequest {
-  conversationId?: string;
-  userId?: string;
-  context?: Context;
-  request: {
-    unstructured?: {
-      text: string;
-    };
-    structured?: StructuredRequest & { slots?: SlotValue[] };
-  };
-}
-
-/**
- *
- */
-export interface ChoiceRequestMetadata {
-  /**
-   *
-   */
-  responseIndex?: number;
-  /**
-   *
-   */
-  messageIndex?: number;
-  /**
-   *
-   */
-  nodeId?: string;
-}
-
-/**
- *
- */
-export interface ConversationHandler {
-  /**
-   *
-   */
-  sendText: (text: string, context?: Context) => void;
-  /**
-   *
-   */
-  sendSlots: (slots: SlotsRecordOrArray, context?: Context) => void;
-  /**
-   *
-   */
-  sendChoice: (
-    choiceId: string,
-    context?: Context,
-    metadata?: ChoiceRequestMetadata,
-  ) => void;
-  /**
-   *
-   */
-  sendWelcomeIntent: (context?: Context) => void;
-  /**
-   *
-   */
-  sendIntent: (intentId: string, context?: Context) => void;
-  /**
-   *
-   */
-  sendStructured: (request: StructuredRequest, context?: Context) => void;
-  /**
-   *
-   */
-  subscribe: (subscriber: Subscriber) => () => void;
-  /**
-   *
-   */
-  unsubscribe: (subscriber: Subscriber) => void;
-  /**
-   *
-   */
-  unsubscribeAll: () => void;
-  /**
-   *
-   */
-  currentConversationId: () => string | undefined;
-  /**
-   *
-   */
-  reset: (options?: {
-    /**
-     *
-     */
-    clearResponses?: boolean;
-  }) => void;
-  /**
-   *
-   */
-  destroy: () => void;
-}
-
-interface InternalState {
-  responses: Response[];
-  conversationId: string;
-  userId?: string;
-}
-
-const fromInternal = (internalState: InternalState): State =>
-  internalState.responses;
-
-const safeJsonParse = (val: string): any => {
-  try {
-    const json = JSON.parse(val);
-    return json;
-  } catch (_err) {
-    return null;
-  }
-};
-
-/**
- *
- */
-export type Subscriber = (response: Response[], newResponse?: Response) => void;
-
-// Helper method to decide when a conversation needs to be re-initialized (e.g. bot URL change)
-export const shouldReinitialize = (
-  config1: Config,
-  config2: Config,
-): boolean => {
-  return !equals(
-    omit(["failureMessage"], config1),
-    omit(["failureMessage"], config2),
-  );
-};
-
-export const createConversation = (config: Config): ConversationHandler => {
+export default function createConversation(
+  config: Config,
+): ConversationHandler {
   let socket: ReconnectingWebSocket | undefined;
 
   // Check if the bot URL has a language code appended to it
@@ -874,14 +379,539 @@ export const createConversation = (config: Config): ConversationHandler => {
       }
     },
   };
+}
+
+/**
+ *
+ */
+export interface ConversationHandler {
+  /**
+   *
+   */
+  sendText: (text: string, context?: Context) => void;
+  /**
+   *
+   */
+  sendSlots: (slots: SlotsRecordOrArray, context?: Context) => void;
+  /**
+   *
+   */
+  sendChoice: (
+    choiceId: string,
+    context?: Context,
+    metadata?: ChoiceRequestMetadata,
+  ) => void;
+  /**
+   *
+   */
+  sendWelcomeIntent: (context?: Context) => void;
+  /**
+   *
+   */
+  sendIntent: (intentId: string, context?: Context) => void;
+  /**
+   *
+   */
+  sendStructured: (request: StructuredRequest, context?: Context) => void;
+  /**
+   *
+   */
+  subscribe: (subscriber: Subscriber) => () => void;
+  /**
+   *
+   */
+  unsubscribe: (subscriber: Subscriber) => void;
+  /**
+   *
+   */
+  unsubscribeAll: () => void;
+  /**
+   *
+   */
+  currentConversationId: () => string | undefined;
+  /**
+   *
+   */
+  reset: (options?: {
+    /**
+     *
+     */
+    clearResponses?: boolean;
+  }) => void;
+  /**
+   *
+   */
+  destroy: () => void;
+}
+
+/**
+ * Context to send back to the bot, for usage later in the intent.
+ */
+export type Context = Record<string, any>;
+
+/**
+ * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
+ *
+ * An array of `SlotValue` objects is equivalent to a {@link SlotsRecord}.
+ */
+export interface SlotValue {
+  /**
+   * The attached slot's name
+   */
+  slotId: string;
+  /**
+   * Usually this will be a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
+   * for custom slots, this can optionally be the value's ID.
+   */
+  value: any;
+}
+
+/**
+ * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
+ *
+ * `SlotRecord` Keys are the attached slot's name
+ *
+ * `SlotRecord` Values are usually a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
+ * for custom slots, this can optionally be the value's ID.
+ *
+ * A `SlotsRecord` is equivalent to an array of {@link SlotValue} objects.
+ */
+export type SlotsRecord = Record<string, any>;
+
+/**
+ * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
+ *
+ * Supports either a {@link SlotsRecord} or an array of {@link SlotValue} objects
+ */
+export type SlotsRecordOrArray = SlotsRecord | SlotValue[];
+
+/**
+ * A message from the bot
+ *
+ * See also:
+ * - {@link UserResponse}
+ * - {@link FailureMessage}
+ * - {@link Response}
+ */
+export interface BotResponse {
+  /**
+   * The type of the response is `"bot"` for bot and `"user"` for user.
+   */
+  type: "bot";
+  /**
+   * When the response was received
+   */
+  receivedAt: Time;
+  /**
+   * The payload of the response
+   */
+  payload: BotResponsePayload;
+}
+
+/**
+ * The response when the bot sends a message.
+ */
+export interface BotResponsePayload {
+  /**
+   * If there isn't some interaction by this time, the conversation will expire.
+   */
+  expirationTimestamp?: number;
+  /**
+   * The active conversation ID. If this is null, a new conversation will be started.
+   */
+  conversationId?: string;
+  /**
+   *
+   */
+  messages: BotMessage[];
+  /**
+   *
+   */
+  metadata?: BotResponseMetadata;
+  /**
+   *
+   */
+  payload?: string;
+  /**
+   *
+   */
+  modalities?: Record<string, any>;
+  /**
+   * Any context the bot knows about the current conversation.
+   */
+  context?: Context;
+}
+
+/**
+ *
+ */
+export interface BotResponseMetadata {
+  /**
+   *
+   */
+  intentId?: string;
+  /**
+   *
+   */
+  escalation?: boolean;
+  /**
+   *
+   */
+  frustration?: boolean;
+  /**
+   *
+   */
+  incomprehension?: boolean;
+  /**
+   *
+   */
+  hasPendingDataRequest?: boolean;
+}
+
+/**
+ *
+ */
+export interface BotMessage {
+  /**
+   *
+   */
+  messageId?: string;
+  /**
+   *
+   */
+  nodeId?: string;
+  /**
+   *
+   */
+  text: string;
+  /**
+   *
+   */
+  choices: Choice[];
+  /**
+   *
+   */
+  selectedChoiceId?: string;
+}
+
+/**
+ *
+ */
+export interface Choice {
+  /**
+   *
+   */
+  choiceId: string;
+  /**
+   *
+   */
+  choiceText: string;
+  /**
+   *
+   */
+  choicePayload?: string;
+}
+
+// User message
+
+/**
+ *
+ */
+export interface UserResponse {
+  /**
+   * The type of the response is `"bot"` for bot and `"user"` for user.
+   */
+  type: "user";
+  /**
+   *
+   */
+  receivedAt: Time;
+  /**
+   *
+   */
+  payload: UserResponsePayload;
+}
+
+/**
+ *
+ */
+export type UserResponsePayload =
+  | {
+      /**
+       *
+       */
+      type: "text";
+      /**
+       *
+       */
+      text: string;
+      /**
+       *
+       */
+      context?: Context;
+    }
+  | {
+      /**
+       *
+       */
+      type: "choice";
+      /**
+       *
+       */
+      choiceId: string;
+      /**
+       *
+       */
+      context?: Context;
+    }
+  | ({
+      /**
+       *
+       */
+      type: "structured";
+      /**
+       *
+       */
+      context?: Context;
+    } & StructuredRequest);
+
+// Failure message
+
+/**
+ *
+ */
+export interface FailureMessage {
+  /**
+   *
+   */
+  type: "failure";
+  /**
+   *
+   */
+  payload: {
+    /**
+     *
+     */
+    text: string;
+  };
+  /**
+   *
+   */
+  receivedAt: Time;
+}
+
+/**
+ *
+ */
+export type Response = BotResponse | UserResponse | FailureMessage;
+
+/**
+ *
+ */
+export type Time = number;
+
+// Config and state
+
+/**
+ *
+ */
+export type Environment = "production" | "development";
+
+/**
+ * The config to create a conversation.
+ * `botUrl` and
+ */
+export interface Config {
+  /**
+   * Fetch this from the bot's Deployment page.
+   */
+  botUrl: string;
+  /**
+   *
+   */
+  conversationId?: string;
+  /**
+   *
+   */
+  userId?: string;
+  /**
+   *
+   */
+  responses?: Response[];
+  /**
+   *
+   */
+  failureMessage?: string;
+  /**
+   *
+   */
+  environment?: Environment;
+  /**
+   *
+   */
+  headers: Record<string, string> & { "nlx-api-key": string };
+  /**
+   *
+   */
+  languageCode: string;
+  // Experimental settings
+  /**
+   *
+   */
+  experimental?: {
+    // Simulate alternative channel types
+    /**
+     *
+     */
+    channelType?: string;
+    // Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio
+    /**
+     *
+     */
+    completeBotUrl?: boolean;
+  };
+}
+
+const welcomeIntent = "NLX.Welcome";
+
+const defaultFailureMessage = "We encountered an issue. Please try again soon.";
+
+/**
+ *
+ */
+export type State = Response[];
+
+const normalizeSlots = (
+  slotsRecordOrArray: SlotsRecordOrArray,
+): SlotValue[] => {
+  if (Array.isArray(slotsRecordOrArray)) {
+    return slotsRecordOrArray;
+  }
+  return Object.entries(slotsRecordOrArray).map(([key, value]) => ({
+    slotId: key,
+    value,
+  }));
 };
 
 /**
  *
- * @param fn - the function to wrap
- * @param convo - the whole conversation handler (from {@link createConversation})
- * @param timeout - the timeout in milliseconds, defaults to 10,000
- * @returns A wrapped version of the function that returns a promise with its response.
+ */
+export interface StructuredRequest {
+  /**
+   *
+   */
+  choiceId?: string;
+  /**
+   *
+   */
+  intentId?: string;
+  /**
+   *
+   */
+  nodeId?: string;
+  /**
+   *
+   */
+  slots?: SlotsRecordOrArray;
+  /**
+   *
+   */
+  poll?: boolean;
+}
+
+interface BotRequest {
+  conversationId?: string;
+  userId?: string;
+  context?: Context;
+  request: {
+    unstructured?: {
+      text: string;
+    };
+    structured?: StructuredRequest & { slots?: SlotValue[] };
+  };
+}
+
+/**
+ *
+ */
+export interface ChoiceRequestMetadata {
+  /**
+   *
+   */
+  responseIndex?: number;
+  /**
+   *
+   */
+  messageIndex?: number;
+  /**
+   *
+   */
+  nodeId?: string;
+}
+
+interface InternalState {
+  responses: Response[];
+  conversationId: string;
+  userId?: string;
+}
+
+const fromInternal = (internalState: InternalState): State =>
+  internalState.responses;
+
+const safeJsonParse = (val: string): any => {
+  try {
+    const json = JSON.parse(val);
+    return json;
+  } catch (_err) {
+    return null;
+  }
+};
+
+/**
+ *
+ */
+export type Subscriber = (response: Response[], newResponse?: Response) => void;
+
+/**
+ * Helper method to decide when a new {@link Config} requires creating a new {@link ConversationHandler} or whether the old `Config`'s
+ * `ConversationHandler` can be used.
+ *
+ * The order of configs doesn't matter.
+ * @param config1 -
+ * @param config2 -
+ * @returns true if `createConversation` should be called again
+ */
+export const shouldReinitialize = (
+  config1: Config,
+  config2: Config,
+): boolean => {
+  return !equals(
+    omit(["failureMessage"], config1),
+    omit(["failureMessage"], config2),
+  );
+};
+
+/**
+ * This package is intentionally designed with a subscription-based API as opposed to a promise-based one where each message corresponds to a single bot response, available asynchronously.
+ *
+ * If you need a promise-based wrapper, you can use the `promisify` helper available in the package:
+ * @example
+ * ```typescript
+ * import { createConversation, promisify } from "@nlxai/chat-core";
+ *
+ * const convo = createConversation(config);
+ *
+ * const sendTextWrapped = promisify(convo.sendText, convo);
+ *
+ * sendTextWrapped("Hello").then((response) => {
+ *   console.log(response);
+ * });
+ * ```
+ * @typeParam T - the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context`
+ * @param fn - the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.)
+ * @param convo - the `ConversationHandler` (from {@link createConversation})
+ * @param timeout - the timeout in milliseconds
+ * @returns A wrapped version of the function that returns a promise that resolves to the Conversation's next response.
  */
 export function promisify<T>(
   fn: (payload: T) => void,
@@ -909,5 +939,3 @@ export function promisify<T>(
     });
   };
 }
-
-export default createConversation;

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -6,111 +6,312 @@ import packageJson from "../package.json";
 
 // Bot response
 
+/**
+ *
+ */
 export type Context = Record<string, any>;
 
+/**
+ *
+ */
 export interface SlotValue {
+  /**
+   *
+   */
   slotId: string;
+  /**
+   *
+   */
   value: any;
 }
 
+/**
+ *
+ */
 export type SlotsRecord = Record<string, any>;
 
+/**
+ *
+ */
 export type SlotsRecordOrArray = SlotsRecord | SlotValue[];
 
+/**
+ *
+ */
 export interface BotResponse {
+  /**
+   *
+   */
   type: "bot";
+  /**
+   *
+   */
   receivedAt: Time;
+  /**
+   *
+   */
   payload: BotResponsePayload;
 }
 
+/**
+ *
+ */
 export interface BotResponsePayload {
+  /**
+   *
+   */
   expirationTimestamp?: number;
+  /**
+   *
+   */
   conversationId?: string;
+  /**
+   *
+   */
   messages: BotMessage[];
+  /**
+   *
+   */
   metadata?: BotResponseMetadata;
+  /**
+   *
+   */
   payload?: string;
+  /**
+   *
+   */
   modalities?: Record<string, any>;
+  /**
+   *
+   */
   context?: Context;
 }
 
+/**
+ *
+ */
 export interface BotResponseMetadata {
+  /**
+   *
+   */
   intentId?: string;
+  /**
+   *
+   */
   escalation?: boolean;
+  /**
+   *
+   */
   frustration?: boolean;
+  /**
+   *
+   */
   incomprehension?: boolean;
+  /**
+   *
+   */
   hasPendingDataRequest?: boolean;
 }
 
+/**
+ *
+ */
 export interface BotMessage {
+  /**
+   *
+   */
   messageId?: string;
+  /**
+   *
+   */
   nodeId?: string;
+  /**
+   *
+   */
   text: string;
+  /**
+   *
+   */
   choices: Choice[];
+  /**
+   *
+   */
   selectedChoiceId?: string;
 }
 
+/**
+ *
+ */
 export interface Choice {
+  /**
+   *
+   */
   choiceId: string;
+  /**
+   *
+   */
   choiceText: string;
+  /**
+   *
+   */
   choicePayload?: string;
 }
 
 // User message
 
+/**
+ *
+ */
 export interface UserResponse {
+  /**
+   *
+   */
   type: "user";
+  /**
+   *
+   */
   receivedAt: Time;
+  /**
+   *
+   */
   payload: UserResponsePayload;
 }
 
+/**
+ *
+ */
 export type UserResponsePayload =
   | {
+      /**
+       *
+       */
       type: "text";
+      /**
+       *
+       */
       text: string;
+      /**
+       *
+       */
       context?: Context;
     }
   | {
+      /**
+       *
+       */
       type: "choice";
+      /**
+       *
+       */
       choiceId: string;
+      /**
+       *
+       */
       context?: Context;
     }
   | ({
+      /**
+       *
+       */
       type: "structured";
+      /**
+       *
+       */
       context?: Context;
     } & StructuredRequest);
 
 // Failure message
 
+/**
+ *
+ */
 export interface FailureMessage {
+  /**
+   *
+   */
   type: "failure";
+  /**
+   *
+   */
   payload: {
+    /**
+     *
+     */
     text: string;
   };
+  /**
+   *
+   */
   receivedAt: Time;
 }
 
+/**
+ *
+ */
 export type Response = BotResponse | UserResponse | FailureMessage;
 
+/**
+ *
+ */
 export type Time = number;
 
 // Config and state
 
+/**
+ *
+ */
 export type Environment = "production" | "development";
 
+/**
+ *
+ */
 export interface Config {
+  /**
+   *
+   */
   botUrl: string;
+  /**
+   *
+   */
   conversationId?: string;
+  /**
+   *
+   */
   userId?: string;
+  /**
+   *
+   */
   responses?: Response[];
+  /**
+   *
+   */
   failureMessage?: string;
+  /**
+   *
+   */
   environment?: Environment;
+  /**
+   *
+   */
   headers: Record<string, string> & { "nlx-api-key": string };
+  /**
+   *
+   */
   languageCode: string;
   // Experimental settings
+  /**
+   *
+   */
   experimental?: {
     // Simulate alternative channel types
+    /**
+     *
+     */
     channelType?: string;
     // Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio
+    /**
+     *
+     */
     completeBotUrl?: boolean;
   };
 }
@@ -119,6 +320,9 @@ const welcomeIntent = "NLX.Welcome";
 
 const defaultFailureMessage = "We encountered an issue. Please try again soon.";
 
+/**
+ *
+ */
 export type State = Response[];
 
 const normalizeSlots = (
@@ -133,11 +337,29 @@ const normalizeSlots = (
   }));
 };
 
+/**
+ *
+ */
 export interface StructuredRequest {
+  /**
+   *
+   */
   choiceId?: string;
+  /**
+   *
+   */
   intentId?: string;
+  /**
+   *
+   */
   nodeId?: string;
+  /**
+   *
+   */
   slots?: SlotsRecordOrArray;
+  /**
+   *
+   */
   poll?: boolean;
 }
 
@@ -159,22 +381,66 @@ interface ChoiceRequestMetadata {
   nodeId?: string;
 }
 
+/**
+ *
+ */
 export interface ConversationHandler {
+  /**
+   *
+   */
   sendText: (text: string, context?: Context) => void;
+  /**
+   *
+   */
   sendSlots: (slots: SlotsRecordOrArray, context?: Context) => void;
+  /**
+   *
+   */
   sendChoice: (
     choiceId: string,
     context?: Context,
     metadata?: ChoiceRequestMetadata,
   ) => void;
+  /**
+   *
+   */
   sendWelcomeIntent: (context?: Context) => void;
+  /**
+   *
+   */
   sendIntent: (intentId: string, context?: Context) => void;
+  /**
+   *
+   */
   sendStructured: (request: StructuredRequest, context?: Context) => void;
+  /**
+   *
+   */
   subscribe: (subscriber: Subscriber) => () => void;
+  /**
+   *
+   */
   unsubscribe: (subscriber: Subscriber) => void;
+  /**
+   *
+   */
   unsubscribeAll: () => void;
+  /**
+   *
+   */
   currentConversationId: () => string | undefined;
-  reset: (options?: { clearResponses?: boolean }) => void;
+  /**
+   *
+   */
+  reset: (options?: {
+    /**
+     *
+     */
+    clearResponses?: boolean;
+  }) => void;
+  /**
+   *
+   */
   destroy: () => void;
 }
 
@@ -578,6 +844,12 @@ export const createConversation = (config: Config): ConversationHandler => {
   };
 };
 
+/**
+ *
+ * @param fn
+ * @param convo
+ * @param timeout
+ */
 export function promisify<T>(
   fn: (payload: T) => void,
   convo: ConversationHandler,

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -135,8 +135,7 @@ export interface BotResponseMetadata {
  */
 export interface BotMessage {
   /**
-   * @hidden
-   * a unique identifier for the message
+   * A unique identifier for the message.
    */
   messageId?: string;
   /**
@@ -297,26 +296,6 @@ export interface Config {
    */
   botUrl: string;
   /**
-   * The conversation ID. If not set, a new conversation will be started.
-   */
-  conversationId?: string;
-  /**
-   * Setting the `userID` allows it to be searchable in bot history, as well as usable via `{System.userId}` in the intent.
-   */
-  userId?: string;
-  /**
-   * Set this to initialize the chat with historical messages.
-   */
-  responses?: Response[];
-  /**
-   * When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
-   */
-  failureMessage?: string;
-  /**
-   * @hidden
-   */
-  environment?: Environment;
-  /**
    * Headers to forward to the NLX API.
    */
   headers: Record<string, string> & {
@@ -325,11 +304,33 @@ export interface Config {
      */
     "nlx-api-key": string;
   };
+
+  /**
+   * Set `conversationId` to continue an existing conversation. If not set, a new conversation will be started.
+   */
+  conversationId?: string;
+  /**
+   * Setting the `userID` allows it to be searchable in bot history, as well as usable via `{System.userId}` in the intent.
+   */
+  userId?: string;
+  /**
+   * When `responses` is set, initialize the chatHandler with historical messages.
+   */
+  responses?: Response[];
+  /**
+   * When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
+   */
+  failureMessage?: string;
   /**
    * The language code to use for the bot. In the browser this can be fetched with `navigator.language`.
    * If you don't have translations, hard-code this to the language code you support.
    */
   languageCode: string;
+  /**
+   * @hidden
+   * this should only be used for NLX internal testing.
+   */
+  environment?: Environment;
   /**
    * Experimental settings
    */

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -7,48 +7,65 @@ import packageJson from "../package.json";
 // Bot response
 
 /**
- *
+ * Context to send back to the bot, for usage later in the intent.
  */
 export type Context = Record<string, any>;
 
 /**
+ * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
  *
+ * An array of `SlotValue` objects is equivalent to a {@link SlotsRecord}.
  */
 export interface SlotValue {
   /**
-   *
+   * The attached slot's name
    */
   slotId: string;
   /**
-   *
+   * Usually this will be a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
+   * for custom slots, this can optionally be the value's ID.
    */
   value: any;
 }
 
 /**
+ * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
  *
+ * `SlotRecord` Keys are the attached slot's name
+ *
+ * `SlotRecord` Values are usually a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
+ * for custom slots, this can optionally be the value's ID.
+ *
+ * A `SlotsRecord` is equivalent to an array of {@link SlotValue} objects.
  */
 export type SlotsRecord = Record<string, any>;
 
 /**
+ * Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
  *
+ * Supports either a {@link SlotsRecord} or an array of {@link SlotValue} objects
  */
 export type SlotsRecordOrArray = SlotsRecord | SlotValue[];
 
 /**
+ * A message from the bot
  *
+ * See also:
+ * - {@link UserResponse}
+ * - {@link FailureMessage}
+ * - {@link Response}
  */
 export interface BotResponse {
   /**
-   *
+   * The type of the response is `"bot"` for bot and `"user"` for user.
    */
   type: "bot";
   /**
-   *
+   * When the response was received
    */
   receivedAt: Time;
   /**
-   *
+   * The payload of the response
    */
   payload: BotResponsePayload;
 }
@@ -164,7 +181,7 @@ export interface Choice {
  */
 export interface UserResponse {
   /**
-   *
+   * The type of the response is `"bot"` for bot and `"user"` for user.
    */
   type: "user";
   /**
@@ -375,9 +392,21 @@ interface BotRequest {
   };
 }
 
+/**
+ *
+ */
 export interface ChoiceRequestMetadata {
+  /**
+   *
+   */
   responseIndex?: number;
+  /**
+   *
+   */
   messageIndex?: number;
+  /**
+   *
+   */
   nodeId?: string;
 }
 
@@ -462,6 +491,9 @@ const safeJsonParse = (val: string): any => {
   }
 };
 
+/**
+ *
+ */
 export type Subscriber = (response: Response[], newResponse?: Response) => void;
 
 // Helper method to decide when a conversation needs to be re-initialized (e.g. bot URL change)
@@ -846,9 +878,10 @@ export const createConversation = (config: Config): ConversationHandler => {
 
 /**
  *
- * @param fn
- * @param convo
- * @param timeout
+ * @param fn - the function to wrap
+ * @param convo - the whole conversation handler (from {@link createConversation})
+ * @param timeout - the timeout in milliseconds, defaults to 10,000
+ * @returns A wrapped version of the function that returns a promise with its response.
  */
 export function promisify<T>(
   fn: (payload: T) => void,
@@ -858,6 +891,7 @@ export function promisify<T>(
   return async (payload: T) => {
     return await new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
+        // TODO should this unsubscribe?
         reject(new Error("The request timed out."));
       }, timeout);
       const subscription = (

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -375,7 +375,7 @@ interface BotRequest {
   };
 }
 
-interface ChoiceRequestMetadata {
+export interface ChoiceRequestMetadata {
   responseIndex?: number;
   messageIndex?: number;
   nodeId?: string;
@@ -462,7 +462,7 @@ const safeJsonParse = (val: string): any => {
   }
 };
 
-type Subscriber = (response: Response[], newResponse?: Response) => void;
+export type Subscriber = (response: Response[], newResponse?: Response) => void;
 
 // Helper method to decide when a conversation needs to be re-initialized (e.g. bot URL change)
 export const shouldReinitialize = (

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -381,70 +381,88 @@ export default function createConversation(
 }
 
 /**
- *
+ * A bundle of functions to interact with a conversation, created by {@link createConversation}.
  */
 export interface ConversationHandler {
   /**
-   *
+   * Send user's message
+   * @param text - the user's message
+   * @param context - [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
    */
   sendText: (text: string, context?: Context) => void;
   /**
-   *
+   * Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settings) to the bot.
+   * @param slots - The slots to populate
+   * @param context - [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
    */
   sendSlots: (slots: SlotsRecordOrArray, context?: Context) => void;
   /**
-   *
+   * Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode/nodes#user-choice) from the bot.
+   * @param choidId - The `choiceId` is in the {@link BotResponse}'s `.payload.messages[].choices[].choiceId` fields
+   * @param context - [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
+   * @param metadata - links the choice to the specific message and node in the conversation.
    */
   sendChoice: (
     choiceId: string,
     context?: Context,
     metadata?: ChoiceRequestMetadata,
   ) => void;
+
   /**
-   *
+   * Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents). This should be done when the user starts interacting with the chat.
+   * @param context - [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
    */
   sendWelcomeIntent: (context?: Context) => void;
+
   /**
-   *
+   * Trigger a specific [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents).
+   * @param intentId - the intent to trigger. The id is the name under the Bot's _Intents_.
+   * @param context - [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
    */
   sendIntent: (intentId: string, context?: Context) => void;
+
   /**
-   *
+   * Send a combination of choice, slots, and intent in one request.
+   * @param request -
+   * @param context - [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
    */
   sendStructured: (request: StructuredRequest, context?: Context) => void;
   /**
-   *
+   * Subscribe a callback to the conversation. On subscribe, the subscriber will receive all of the Responses that the conversation has already received.
+   * @param subscriber - The callback to subscribe
    */
   subscribe: (subscriber: Subscriber) => () => void;
   /**
-   *
+   * Unsubscribe a callback from the conversation.
+   * @param subscriber - The callback to unsubscribe
    */
   unsubscribe: (subscriber: Subscriber) => void;
   /**
-   *
+   * Unsubscribe all callback from the conversation.
    */
   unsubscribeAll: () => void;
   /**
-   *
+   * Get the current conversation ID if it's set, or undefined if there is no conversation.
    */
   currentConversationId: () => string | undefined;
   /**
-   *
+   * Forces a new conversation. If `clearResponses` is set to true, will also clear historical responses passed to subscribers.
+   * Retains all existing subscribers.
    */
   reset: (options?: {
     /**
-     *
+     * If set to true, will clear historical responses passed to subscribers.
      */
     clearResponses?: boolean;
   }) => void;
   /**
-   *
+   * Removes all subscribers and, if using websockets, closes the connection.
    */
   destroy: () => void;
 }
 
 /**
- * Context to send back to the bot, for usage later in the intent.
+ * [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
  */
 export type Context = Record<string, any>;
 
@@ -494,7 +512,7 @@ export type SlotsRecordOrArray = SlotsRecord | SlotValue[];
  */
 export interface BotResponse {
   /**
-   * The type of the response is `"bot"` for bot and `"user"` for user.
+   * The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
    */
   type: "bot";
   /**
@@ -508,7 +526,7 @@ export interface BotResponse {
 }
 
 /**
- * The response when the bot sends a message.
+ * The payload of the bot response
  */
 export interface BotResponsePayload {
   /**
@@ -516,160 +534,170 @@ export interface BotResponsePayload {
    */
   expirationTimestamp?: number;
   /**
-   * The active conversation ID. If this is null, a new conversation will be started.
+   * The active conversation ID. If not set, a new conversation will be started.
    */
   conversationId?: string;
   /**
-   *
+   * Any messages from the bot.
    */
   messages: BotMessage[];
   /**
-   *
+   * Global state about the current conversation
+   * as well as whether the client should poll for more bot responses.
    */
   metadata?: BotResponseMetadata;
   /**
-   *
+   * If configured, the [node's payload.](See: https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode/advanced-messaging-+-functionality#add-functionality)
    */
   payload?: string;
   /**
-   *
+   * If configured, the node's modalities and their payloads.
    */
   modalities?: Record<string, any>;
   /**
-   * Any context the bot knows about the current conversation.
+   * If the node is set to send context, the whole context associated with the conversation.
    */
   context?: Context;
 }
 
 /**
- *
+ * Global state about the current conversation
+ * as well as whether the client should poll for more bot responses.
  */
 export interface BotResponseMetadata {
   /**
-   *
+   * The conversation's intent
    */
   intentId?: string;
   /**
-   *
+   * Whether the current conversation has been marked as incomprehension.
    */
   escalation?: boolean;
   /**
-   *
+   * Whether the current conversation has been marked frustrated
    */
   frustration?: boolean;
   /**
-   *
+   * Whether the current conversation has been marked as incomprehension.
    */
   incomprehension?: boolean;
   /**
-   *
+   * Whether the client should poll for more bot responses.
    */
   hasPendingDataRequest?: boolean;
 }
 
 /**
- *
+ * A message from the bot, as well as any choices the user can make.
  */
 export interface BotMessage {
   /**
-   *
+   * @hidden
+   * a unique identifier for the message
    */
   messageId?: string;
   /**
-   *
+   * The node id that this message is associated with.
+   * This is must be sent with a choice when the user is changing a previously sent choice.
    */
   nodeId?: string;
   /**
-   *
+   * The body of the message. Show this to the user.
    */
   text: string;
   /**
-   *
+   * A selection of choices to show to the user. They may choose one of them.
    */
   choices: Choice[];
   /**
-   *
+   * After a choice has been made by the user, this will be updated locally to the selected choice id.
+   * This field is set locally and does not come from the bot.
    */
   selectedChoiceId?: string;
 }
 
 /**
- *
+ * A choices to show to the user.
  */
 export interface Choice {
   /**
-   *
+   * `choiceId` is used by `sendChoice` to let the user choose this choice.
    */
   choiceId: string;
   /**
-   *
+   * The text of the choice
    */
   choiceText: string;
   /**
-   *
+   * An optional, schemaless payload for the choice.
    */
-  choicePayload?: string;
+  choicePayload?: any;
 }
 
-// User message
-
 /**
+ * A message from the user
+ *
+ * See also:
+ * - {@link BotResponse}
+ * - {@link FailureMessage}
+ * - {@link Response}
  *
  */
 export interface UserResponse {
   /**
-   * The type of the response is `"bot"` for bot and `"user"` for user.
+   * The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
    */
   type: "user";
   /**
-   *
+   * When the response was received
    */
   receivedAt: Time;
   /**
-   *
+   * The payload of the response
    */
   payload: UserResponsePayload;
 }
 
 /**
- *
+ * The payload of the user response
  */
 export type UserResponsePayload =
   | {
       /**
-       *
+       * Set when `sendText` is called.
        */
       type: "text";
       /**
-       *
+       * The user's message
        */
       text: string;
       /**
-       *
+       * [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
        */
       context?: Context;
     }
   | {
       /**
-       *
+       * Set when `sendChoice` is called.
        */
       type: "choice";
       /**
-       *
+       * The `choiceId` passed to `sendChoice`
+       * Correlates to a `choiceId` in the {@link BotResponse}'s `.payload.messages[].choices[].choiceId` fields
        */
       choiceId: string;
       /**
-       *
+       * [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
        */
       context?: Context;
     }
   | ({
       /**
-       *
+       * Set when `sendStructured` is called.
        */
       type: "structured";
       /**
-       *
+       * [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
        */
       context?: Context;
     } & StructuredRequest);
@@ -677,42 +705,42 @@ export type UserResponsePayload =
 // Failure message
 
 /**
- *
+ * A failure message is received when the NLX api is unreachable, or sends an unparsable response.
  */
 export interface FailureMessage {
   /**
-   *
+   * The type of the response is `"bot"` for bot and `"user"` for user.
    */
   type: "failure";
   /**
-   *
+   * The payload only includes an error message.
    */
   payload: {
     /**
-     *
+     * The error message is either the default, or the `failureMessage` set in the {@link Config}.
      */
     text: string;
   };
   /**
-   *
+   * When the failure occurred.
    */
   receivedAt: Time;
 }
 
 /**
- *
+ * A response from the bot or the user.
  */
 export type Response = BotResponse | UserResponse | FailureMessage;
 
 /**
- *
+ * The time value in milliseconds since midnight, January 1, 1970 UTC.
  */
 export type Time = number;
 
 // Config and state
 
 /**
- *
+ * @hidden
  */
 export type Environment = "production" | "development";
 
@@ -726,46 +754,49 @@ export interface Config {
    */
   botUrl: string;
   /**
-   *
+   * The conversation ID. If not set, a new conversation will be started.
    */
   conversationId?: string;
   /**
-   *
+   * TODO I don't know what this is
    */
   userId?: string;
   /**
-   *
+   * Set this to initialize the chat with historical messages.
    */
   responses?: Response[];
   /**
-   *
+   * When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
    */
   failureMessage?: string;
   /**
-   *
+   * @hidden
    */
   environment?: Environment;
   /**
-   *
+   * Headers to forward to the NLX API.
    */
-  headers: Record<string, string> & { "nlx-api-key": string };
+  headers: Record<string, string> & {
+    /**
+     * The `nlx-api-key` is required. Fetch this from the bot's Deployment page.
+     */
+    "nlx-api-key": string;
+  };
   /**
-   *
+   * The language code to use for the bot. In the browser this can be fetched with `navigator.language`.
+   * If you don't have translations, hard-code this to the language code you support.
    */
   languageCode: string;
-  // Experimental settings
   /**
-   *
+   * Experimental settings
    */
   experimental?: {
-    // Simulate alternative channel types
     /**
-     *
+     * Simulate alternative channel types
      */
     channelType?: string;
-    // Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio
     /**
-     *
+     * Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio
      */
     completeBotUrl?: boolean;
   };
@@ -774,11 +805,6 @@ export interface Config {
 const welcomeIntent = "NLX.Welcome";
 
 const defaultFailureMessage = "We encountered an issue. Please try again soon.";
-
-/**
- *
- */
-export type State = Response[];
 
 const normalizeSlots = (
   slotsRecordOrArray: SlotsRecordOrArray,
@@ -793,27 +819,30 @@ const normalizeSlots = (
 };
 
 /**
- *
+ * The body of `sendStructured`
+ * Includes a combination of choice, slots, and intent in one request.
  */
 export interface StructuredRequest {
   /**
-   *
+   * The `choiceId` is in the {@link BotResponse}'s `.payload.messages[].choices[].choiceId` fields
    */
   choiceId?: string;
   /**
-   *
-   */
-  intentId?: string;
-  /**
-   *
+   * Required if you want to change a choice that's already been sent.
+   * The `nodeId` can be found in the corresponding {@link BotMessage}.
    */
   nodeId?: string;
   /**
-   *
+   * The intent to trigger. The `intentId` is the name under the Bot's _Intents_.
+   */
+  intentId?: string;
+  /**
+   * The slots to populate
    */
   slots?: SlotsRecordOrArray;
   /**
-   *
+   * @hidden
+   * This is used internally to indicate that the client is polling the bot for more data.
    */
   poll?: boolean;
 }
@@ -831,19 +860,24 @@ interface BotRequest {
 }
 
 /**
- *
+ * Helps link the choice to the specific message in the conversation.
  */
 export interface ChoiceRequestMetadata {
   /**
-   *
+   * The index of the {@link Response} associated with this choice.
+   * Setting this ensures that local state's `selectedChoiceId` on the corresponding {@link BotResponse} is set.
+   * It is not sent to the bot.
    */
   responseIndex?: number;
   /**
-   *
+   * The index of the {@link BotMessage} associated with this choice.
+   * Setting this ensures that local state's `selectedChoiceId` on the corresponding {@link BotResponse} is set.
+   * It is not sent to the bot.
    */
   messageIndex?: number;
   /**
-   *
+   * Required if you want to change a choice that's already been sent.
+   * The `nodeId` can be found in the corresponding {@link BotMessage}.
    */
   nodeId?: string;
 }
@@ -854,7 +888,7 @@ interface InternalState {
   userId?: string;
 }
 
-const fromInternal = (internalState: InternalState): State =>
+const fromInternal = (internalState: InternalState): Response[] =>
   internalState.responses;
 
 const safeJsonParse = (val: string): any => {
@@ -867,7 +901,7 @@ const safeJsonParse = (val: string): any => {
 };
 
 /**
- *
+ * The callback function for listening to all responses.
  */
 export type Subscriber = (response: Response[], newResponse?: Response) => void;
 

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -6,7 +6,6 @@ import packageJson from "../package.json";
 
 /**
  * Call this to create a conversation handler.
- *
  * @param config -
  * @returns The {@link ConversationHandler} is a bundle of functions to interact with the conversation.
  */

--- a/packages/chat-core/tsdoc.json
+++ b/packages/chat-core/tsdoc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["typedoc/tsdoc.json"],
+  "noStandardTags": false,
+  "tagDefinitions": []
+}

--- a/packages/chat-core/typedoc.cjs
+++ b/packages/chat-core/typedoc.cjs
@@ -1,16 +1,14 @@
-// @type {import('typedoc').TypeDocOptions}
+/** @type { import('typedoc').TypeDocOptions & { hideInPageTOC?: boolean, hideBreadcrumbs?: boolean} } */
 module.exports = {
-  sort: ["source-order", "kind", "instance-first", "alphabetical"],
-  entryPoints: ["./src/index.ts"],
-  out: "docs",
-  validation: {
-    notExported: true,
-    invalidLink: true,
-    // notDocumented: true,
-  },
-  treatWarningsAsErrors: true,
-  treatValidationWarningsAsErrors: true,
   categoryOrder: ["Setup", "Client"],
+  entryPoints: ["./src/index.ts"],
+  hideBreadcrumbs: true,
+  hideInPageTOC: true,
+  out: "docs",
   plugin: ["typedoc-plugin-markdown"],
   readme: "none",
+  sort: ["source-order", "kind", "instance-first", "alphabetical"],
+  treatValidationWarningsAsErrors: true,
+  treatWarningsAsErrors: true,
+  validation: { notExported: true, invalidLink: true, notDocumented: true },
 };

--- a/packages/chat-core/typedoc.cjs
+++ b/packages/chat-core/typedoc.cjs
@@ -1,0 +1,12 @@
+/** @type {import('typedoc').TypeDocOptions} */
+module.exports = {
+  sort: ["source-order", "kind", "instance-first", "alphabetical"],
+  entryPoints: ["./src/index.ts"],
+  out: "docs",
+  validation: { notExported: true, invalidLink: true, notDocumented: true },
+  treatWarningsAsErrors: true,
+  treatValidationWarningsAsErrors: true,
+  categoryOrder: ["Setup", "Client"],
+  // plugin: ["typedoc-plugin-markdown"],
+  readme: "none",
+};

--- a/packages/chat-core/typedoc.cjs
+++ b/packages/chat-core/typedoc.cjs
@@ -1,12 +1,16 @@
-/** @type {import('typedoc').TypeDocOptions} */
+// @type {import('typedoc').TypeDocOptions}
 module.exports = {
   sort: ["source-order", "kind", "instance-first", "alphabetical"],
   entryPoints: ["./src/index.ts"],
   out: "docs",
-  validation: { notExported: true, invalidLink: true, notDocumented: true },
+  validation: {
+    notExported: true,
+    invalidLink: true,
+    // notDocumented: true,
+  },
   treatWarningsAsErrors: true,
   treatValidationWarningsAsErrors: true,
   categoryOrder: ["Setup", "Client"],
-  // plugin: ["typedoc-plugin-markdown"],
+  plugin: ["typedoc-plugin-markdown"],
   readme: "none",
 };

--- a/packages/eslint-config-nlx/documentation.js
+++ b/packages/eslint-config-nlx/documentation.js
@@ -16,4 +16,12 @@ module.exports = {
     "jsdoc/check-param-names": ["error", { checkDestructured: false }],
     "tsdoc/syntax": "error",
   },
+  overrides: [
+    {
+      files: ["*.cjs", "*.js"],
+      rules: {
+        "tsdoc/syntax": "off",
+      }
+    }
+  ]
 };

--- a/packages/eslint-config-nlx/documentation.js
+++ b/packages/eslint-config-nlx/documentation.js
@@ -11,7 +11,7 @@ module.exports = {
         contexts: ["TSTypeAliasDeclaration","TSInterfaceDeclaration","TSMethodSignature","TSPropertySignature"]
       }
     ],
-    "jsdoc/check-tag-names": ["error", { definedTags: ["category", "hidden"] }],
+    "jsdoc/check-tag-names": ["error", { definedTags: ["category", "hidden", "typeParam"] }],
     "jsdoc/require-param": ["error", { checkDestructured: false }],
     "jsdoc/check-param-names": ["error", { checkDestructured: false }],
     "tsdoc/syntax": "error",

--- a/packages/voice-compass/package.json
+++ b/packages/voice-compass/package.json
@@ -9,11 +9,12 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "rm -rf lib && rollup -c",
-    "docs": "typedoc",
+    "docs": "rm -rf docs/ && typedoc && concat-md --decrease-title-levels --dir-name-as-title docs/ > docs/index.md",
     "lint:check": "eslint src/ --ext .ts,.tsx,.js,.jsx",
     "lint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix",
     "prepublish": "npm run build",
-    "publish-docs": "npm run docs && concat-md --decrease-title-levels --dir-name-as-title docs/ > ../website/src/content/06-03-multimodal-api-reference.md",
+    "preview-docs": "npm run docs && comrak --unsafe --gfm  -o docs/index.html docs/index.md && open docs/index.html",
+    "publish-docs": "npm run docs && mv docs/index.md ../website/src/content/06-03-multimodal-api-reference.md",
     "test": "jest",
     "tsc": "tsc"
   },

--- a/packages/voice-compass/src/index.ts
+++ b/packages/voice-compass/src/index.ts
@@ -98,13 +98,13 @@ export interface Client {
    *
    *
    *   _Note: Must be a valid UUID_
-   * @param context -  context to send back to the voice bot, for usage later in the intent.
+   * @param context - [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent.
    */
   sendStep: (stepId: string, context?: Context) => Promise<void>;
 }
 
 /**
- * context to send back to the voice bot, for usage later in the intent.
+ * [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent.
  * @category Client
  */
 export type Context = Record<string, any>;

--- a/packages/voice-compass/typedoc.cjs
+++ b/packages/voice-compass/typedoc.cjs
@@ -1,12 +1,14 @@
-/** @type {import('typedoc').TypeDocOptions} */
+/** @type { import('typedoc').TypeDocOptions & { hideInPageTOC?: boolean, hideBreadcrumbs?: boolean} } */
 module.exports = {
-  sort: ["source-order", "kind", "instance-first", "alphabetical"],
-  entryPoints: ["./src/index.ts"],
-  out: "docs",
-  validation: { notExported: true, invalidLink: true, notDocumented: true },
-  treatWarningsAsErrors: true,
-  treatValidationWarningsAsErrors: true,
   categoryOrder: ["Setup", "Client"],
+  entryPoints: ["./src/index.ts"],
+  hideBreadcrumbs: true,
+  hideInPageTOC: true,
+  out: "docs",
   plugin: ["typedoc-plugin-markdown"],
   readme: "none",
+  sort: ["source-order", "kind", "instance-first", "alphabetical"],
+  treatValidationWarningsAsErrors: true,
+  treatWarningsAsErrors: true,
+  validation: { notExported: true, invalidLink: true, notDocumented: true },
 };

--- a/packages/voice-compass/typedoc.cjs
+++ b/packages/voice-compass/typedoc.cjs
@@ -7,6 +7,6 @@ module.exports = {
   treatWarningsAsErrors: true,
   treatValidationWarningsAsErrors: true,
   categoryOrder: ["Setup", "Client"],
-  // plugin: ["typedoc-plugin-markdown"],
+  plugin: ["typedoc-plugin-markdown"],
   readme: "none",
 };

--- a/packages/website/src/content/05-02-headless-api-reference.md
+++ b/packages/website/src/content/05-02-headless-api-reference.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[index.ts:10](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L10)
+[index.ts:10](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L10)
 
 ___
 
@@ -47,7 +47,7 @@ A `SlotsRecord` is equivalent to an array of [SlotValue](#interfacesslotvaluemd)
 
 #### Defined in
 
-[index.ts:39](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L39)
+[index.ts:39](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L39)
 
 ___
 
@@ -61,7 +61,7 @@ Supports either a [SlotsRecord](#slotsrecord) or an array of [SlotValue](#interf
 
 #### Defined in
 
-[index.ts:46](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L46)
+[index.ts:46](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L46)
 
 ___
 
@@ -73,7 +73,7 @@ The payload of the user response
 
 #### Defined in
 
-[index.ts:207](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L207)
+[index.ts:206](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L206)
 
 ___
 
@@ -85,7 +85,7 @@ A response from the bot or the user.
 
 #### Defined in
 
-[index.ts:276](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L276)
+[index.ts:275](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L275)
 
 ___
 
@@ -97,7 +97,7 @@ The time value in milliseconds since midnight, January 1, 1970 UTC.
 
 #### Defined in
 
-[index.ts:281](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L281)
+[index.ts:280](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L280)
 
 ___
 
@@ -124,7 +124,7 @@ The callback function for listening to all responses.
 
 #### Defined in
 
-[index.ts:530](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L530)
+[index.ts:531](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L531)
 
 ## Functions
 
@@ -152,7 +152,7 @@ true if `createConversation` should be called again
 
 #### Defined in
 
-[index.ts:541](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L541)
+[index.ts:542](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L542)
 
 ___
 
@@ -176,7 +176,7 @@ The [ConversationHandler](#interfacesconversationhandlermd) is a bundle of funct
 
 #### Defined in
 
-[index.ts:556](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L556)
+[index.ts:557](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L557)
 
 ___
 
@@ -236,7 +236,7 @@ sendTextWrapped("Hello").then((response) => {
 
 #### Defined in
 
-[index.ts:949](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L949)
+[index.ts:950](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L950)
 
 
 <a name="indexmd"></a>
@@ -253,6 +253,18 @@ A message from the bot, as well as any choices the user can make.
 
 ### Properties
 
+#### messageId
+
+• `Optional` **messageId**: `string`
+
+A unique identifier for the message.
+
+##### Defined in
+
+[index.ts:140](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L140)
+
+___
+
 #### nodeId
 
 • `Optional` **nodeId**: `string`
@@ -262,7 +274,7 @@ This is must be sent with a choice when the user is changing a previously sent c
 
 ##### Defined in
 
-[index.ts:146](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L146)
+[index.ts:145](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L145)
 
 ___
 
@@ -274,7 +286,7 @@ The body of the message. Show this to the user.
 
 ##### Defined in
 
-[index.ts:150](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L150)
+[index.ts:149](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L149)
 
 ___
 
@@ -286,7 +298,7 @@ A selection of choices to show to the user. They may choose one of them.
 
 ##### Defined in
 
-[index.ts:154](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L154)
+[index.ts:153](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L153)
 
 ___
 
@@ -299,7 +311,7 @@ This field is set locally and does not come from the bot.
 
 ##### Defined in
 
-[index.ts:159](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L159)
+[index.ts:158](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L158)
 
 
 <a name="interfacesbotresponsemd"></a>
@@ -323,7 +335,7 @@ The type of the response is `"bot"` for bot and `"user"` for user, and "failure"
 
 ##### Defined in
 
-[index.ts:60](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L60)
+[index.ts:60](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L60)
 
 ___
 
@@ -335,7 +347,7 @@ When the response was received
 
 ##### Defined in
 
-[index.ts:64](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L64)
+[index.ts:64](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L64)
 
 ___
 
@@ -347,7 +359,7 @@ The payload of the response
 
 ##### Defined in
 
-[index.ts:68](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L68)
+[index.ts:68](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L68)
 
 
 <a name="interfacesbotresponsemetadatamd"></a>
@@ -367,7 +379,7 @@ The conversation's intent
 
 ##### Defined in
 
-[index.ts:114](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L114)
+[index.ts:114](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L114)
 
 ___
 
@@ -379,7 +391,7 @@ Whether the current conversation has been marked as incomprehension.
 
 ##### Defined in
 
-[index.ts:118](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L118)
+[index.ts:118](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L118)
 
 ___
 
@@ -391,7 +403,7 @@ Whether the current conversation has been marked frustrated
 
 ##### Defined in
 
-[index.ts:122](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L122)
+[index.ts:122](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L122)
 
 ___
 
@@ -403,7 +415,7 @@ Whether the current conversation has been marked as incomprehension.
 
 ##### Defined in
 
-[index.ts:126](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L126)
+[index.ts:126](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L126)
 
 ___
 
@@ -415,7 +427,7 @@ Whether the client should poll for more bot responses.
 
 ##### Defined in
 
-[index.ts:130](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L130)
+[index.ts:130](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L130)
 
 
 <a name="interfacesbotresponsepayloadmd"></a>
@@ -434,7 +446,7 @@ If there isn't some interaction by this time, the conversation will expire.
 
 ##### Defined in
 
-[index.ts:78](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L78)
+[index.ts:78](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L78)
 
 ___
 
@@ -446,7 +458,7 @@ The active conversation ID. If not set, a new conversation will be started.
 
 ##### Defined in
 
-[index.ts:82](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L82)
+[index.ts:82](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L82)
 
 ___
 
@@ -458,7 +470,7 @@ Any messages from the bot.
 
 ##### Defined in
 
-[index.ts:86](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L86)
+[index.ts:86](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L86)
 
 ___
 
@@ -471,7 +483,7 @@ as well as whether the client should poll for more bot responses.
 
 ##### Defined in
 
-[index.ts:91](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L91)
+[index.ts:91](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L91)
 
 ___
 
@@ -483,7 +495,7 @@ If configured, the [node's payload.](#add-functionality)
 
 ##### Defined in
 
-[index.ts:95](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L95)
+[index.ts:95](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L95)
 
 ___
 
@@ -495,7 +507,7 @@ If configured, the node's modalities and their payloads.
 
 ##### Defined in
 
-[index.ts:99](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L99)
+[index.ts:99](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L99)
 
 ___
 
@@ -507,7 +519,7 @@ If the node is set to send context, the whole context associated with the conver
 
 ##### Defined in
 
-[index.ts:103](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L103)
+[index.ts:103](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L103)
 
 
 <a name="interfaceschoicemd"></a>
@@ -526,7 +538,7 @@ A choices to show to the user.
 
 ##### Defined in
 
-[index.ts:169](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L169)
+[index.ts:168](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L168)
 
 ___
 
@@ -538,7 +550,7 @@ The text of the choice
 
 ##### Defined in
 
-[index.ts:173](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L173)
+[index.ts:172](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L172)
 
 ___
 
@@ -550,7 +562,7 @@ An optional, schemaless payload for the choice.
 
 ##### Defined in
 
-[index.ts:177](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L177)
+[index.ts:176](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L176)
 
 
 <a name="interfaceschoicerequestmetadatamd"></a>
@@ -571,7 +583,7 @@ It is not sent to the bot.
 
 ##### Defined in
 
-[index.ts:414](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L414)
+[index.ts:415](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L415)
 
 ___
 
@@ -585,7 +597,7 @@ It is not sent to the bot.
 
 ##### Defined in
 
-[index.ts:420](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L420)
+[index.ts:421](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L421)
 
 ___
 
@@ -598,7 +610,7 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 ##### Defined in
 
-[index.ts:425](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L425)
+[index.ts:426](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L426)
 
 
 <a name="interfacesconfigmd"></a>
@@ -618,55 +630,7 @@ Fetch this from the bot's Deployment page.
 
 ##### Defined in
 
-[index.ts:298](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L298)
-
-___
-
-#### conversationId
-
-• `Optional` **conversationId**: `string`
-
-The conversation ID. If not set, a new conversation will be started.
-
-##### Defined in
-
-[index.ts:302](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L302)
-
-___
-
-#### userId
-
-• `Optional` **userId**: `string`
-
-TODO I don't know what this is
-
-##### Defined in
-
-[index.ts:306](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L306)
-
-___
-
-#### responses
-
-• `Optional` **responses**: [`Response`](#response)[]
-
-Set this to initialize the chat with historical messages.
-
-##### Defined in
-
-[index.ts:310](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L310)
-
-___
-
-#### failureMessage
-
-• `Optional` **failureMessage**: `string`
-
-When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
-
-##### Defined in
-
-[index.ts:314](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L314)
+[index.ts:297](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L297)
 
 ___
 
@@ -678,7 +642,55 @@ Headers to forward to the NLX API.
 
 ##### Defined in
 
-[index.ts:322](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L322)
+[index.ts:301](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L301)
+
+___
+
+#### conversationId
+
+• `Optional` **conversationId**: `string`
+
+Set `conversationId` to continue an existing conversation. If not set, a new conversation will be started.
+
+##### Defined in
+
+[index.ts:311](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L311)
+
+___
+
+#### userId
+
+• `Optional` **userId**: `string`
+
+Setting the `userID` allows it to be searchable in bot history, as well as usable via `{System.userId}` in the intent.
+
+##### Defined in
+
+[index.ts:315](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L315)
+
+___
+
+#### responses
+
+• `Optional` **responses**: [`Response`](#response)[]
+
+When `responses` is set, initialize the chatHandler with historical messages.
+
+##### Defined in
+
+[index.ts:319](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L319)
+
+___
+
+#### failureMessage
+
+• `Optional` **failureMessage**: `string`
+
+When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
+
+##### Defined in
+
+[index.ts:323](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L323)
 
 ___
 
@@ -691,7 +703,7 @@ If you don't have translations, hard-code this to the language code you support.
 
 ##### Defined in
 
-[index.ts:332](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L332)
+[index.ts:328](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L328)
 
 ___
 
@@ -710,7 +722,7 @@ Experimental settings
 
 ##### Defined in
 
-[index.ts:336](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L336)
+[index.ts:337](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L337)
 
 
 <a name="interfacesconversationhandlermd"></a>
@@ -744,7 +756,7 @@ Send user's message
 
 ##### Defined in
 
-[index.ts:437](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L437)
+[index.ts:438](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L438)
 
 ___
 
@@ -771,7 +783,7 @@ Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settin
 
 ##### Defined in
 
-[index.ts:443](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L443)
+[index.ts:444](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L444)
 
 ___
 
@@ -799,7 +811,7 @@ Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows
 
 ##### Defined in
 
-[index.ts:450](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L450)
+[index.ts:451](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L451)
 
 ___
 
@@ -825,7 +837,7 @@ Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-
 
 ##### Defined in
 
-[index.ts:460](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L460)
+[index.ts:461](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L461)
 
 ___
 
@@ -852,7 +864,7 @@ Trigger a specific [intent](https://docs.studio.nlx.ai/intents/introduction-to-i
 
 ##### Defined in
 
-[index.ts:467](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L467)
+[index.ts:468](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L468)
 
 ___
 
@@ -879,7 +891,7 @@ Send a combination of choice, slots, and intent in one request.
 
 ##### Defined in
 
-[index.ts:474](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L474)
+[index.ts:475](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L475)
 
 ___
 
@@ -911,7 +923,7 @@ Subscribe a callback to the conversation. On subscribe, the subscriber will rece
 
 ##### Defined in
 
-[index.ts:479](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L479)
+[index.ts:480](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L480)
 
 ___
 
@@ -937,7 +949,7 @@ Unsubscribe a callback from the conversation.
 
 ##### Defined in
 
-[index.ts:484](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L484)
+[index.ts:485](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L485)
 
 ___
 
@@ -957,7 +969,7 @@ Unsubscribe all callback from the conversation.
 
 ##### Defined in
 
-[index.ts:488](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L488)
+[index.ts:489](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L489)
 
 ___
 
@@ -977,7 +989,7 @@ Get the current conversation ID if it's set, or undefined if there is no convers
 
 ##### Defined in
 
-[index.ts:492](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L492)
+[index.ts:493](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L493)
 
 ___
 
@@ -1005,7 +1017,7 @@ Retains all existing subscribers.
 
 ##### Defined in
 
-[index.ts:497](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L497)
+[index.ts:498](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L498)
 
 ___
 
@@ -1025,7 +1037,7 @@ Removes all subscribers and, if using websockets, closes the connection.
 
 ##### Defined in
 
-[index.ts:506](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L506)
+[index.ts:507](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L507)
 
 
 <a name="interfacesfailuremessagemd"></a>
@@ -1044,7 +1056,7 @@ The type of the response is `"bot"` for bot and `"user"` for user.
 
 ##### Defined in
 
-[index.ts:257](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L257)
+[index.ts:256](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L256)
 
 ___
 
@@ -1062,7 +1074,7 @@ The payload only includes an error message.
 
 ##### Defined in
 
-[index.ts:261](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L261)
+[index.ts:260](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L260)
 
 ___
 
@@ -1074,7 +1086,7 @@ When the failure occurred.
 
 ##### Defined in
 
-[index.ts:270](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L270)
+[index.ts:269](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L269)
 
 
 <a name="interfacesslotvaluemd"></a>
@@ -1095,7 +1107,7 @@ The attached slot's name
 
 ##### Defined in
 
-[index.ts:21](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L21)
+[index.ts:21](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L21)
 
 ___
 
@@ -1108,7 +1120,7 @@ for custom slots, this can optionally be the value's ID.
 
 ##### Defined in
 
-[index.ts:26](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L26)
+[index.ts:26](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L26)
 
 
 <a name="interfacesstructuredrequestmd"></a>
@@ -1128,7 +1140,7 @@ The `choiceId` is in the [BotResponse](#interfacesbotresponsemd)'s `.payload.mes
 
 ##### Defined in
 
-[index.ts:372](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L372)
+[index.ts:373](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L373)
 
 ___
 
@@ -1141,7 +1153,7 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 ##### Defined in
 
-[index.ts:377](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L377)
+[index.ts:378](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L378)
 
 ___
 
@@ -1153,7 +1165,7 @@ The intent to trigger. The `intentId` is the name under the Bot's _Intents_.
 
 ##### Defined in
 
-[index.ts:381](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L381)
+[index.ts:382](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L382)
 
 ___
 
@@ -1165,7 +1177,7 @@ The slots to populate
 
 ##### Defined in
 
-[index.ts:385](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L385)
+[index.ts:386](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L386)
 
 
 <a name="interfacesuserresponsemd"></a>
@@ -1189,7 +1201,7 @@ The type of the response is `"bot"` for bot and `"user"` for user, and "failure"
 
 ##### Defined in
 
-[index.ts:193](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L193)
+[index.ts:192](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L192)
 
 ___
 
@@ -1201,7 +1213,7 @@ When the response was received
 
 ##### Defined in
 
-[index.ts:197](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L197)
+[index.ts:196](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L196)
 
 ___
 
@@ -1213,4 +1225,4 @@ The payload of the response
 
 ##### Defined in
 
-[index.ts:201](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L201)
+[index.ts:200](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/chat-core/src/index.ts#L200)

--- a/packages/website/src/content/05-02-headless-api-reference.md
+++ b/packages/website/src/content/05-02-headless-api-reference.md
@@ -1,0 +1,1216 @@
+
+<a name="readmemd"></a>
+
+# @nlxai/chat-core
+
+## Interfaces
+
+- [SlotValue](#interfacesslotvaluemd)
+- [BotResponse](#interfacesbotresponsemd)
+- [BotResponsePayload](#interfacesbotresponsepayloadmd)
+- [BotResponseMetadata](#interfacesbotresponsemetadatamd)
+- [BotMessage](#interfacesbotmessagemd)
+- [Choice](#interfaceschoicemd)
+- [UserResponse](#interfacesuserresponsemd)
+- [FailureMessage](#interfacesfailuremessagemd)
+- [Config](#interfacesconfigmd)
+- [StructuredRequest](#interfacesstructuredrequestmd)
+- [ChoiceRequestMetadata](#interfaceschoicerequestmetadatamd)
+- [ConversationHandler](#interfacesconversationhandlermd)
+
+## Type Aliases
+
+### Context
+
+Ƭ **Context**: `Record`\<`string`, `any`\>
+
+[Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
+
+#### Defined in
+
+[index.ts:10](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L10)
+
+___
+
+### SlotsRecord
+
+Ƭ **SlotsRecord**: `Record`\<`string`, `any`\>
+
+Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
+
+`SlotRecord` Keys are the attached slot's name
+
+`SlotRecord` Values are usually a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
+for custom slots, this can optionally be the value's ID.
+
+A `SlotsRecord` is equivalent to an array of [SlotValue](#interfacesslotvaluemd) objects.
+
+#### Defined in
+
+[index.ts:39](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L39)
+
+___
+
+### SlotsRecordOrArray
+
+Ƭ **SlotsRecordOrArray**: [`SlotsRecord`](#slotsrecord) \| [`SlotValue`](#interfacesslotvaluemd)[]
+
+Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
+
+Supports either a [SlotsRecord](#slotsrecord) or an array of [SlotValue](#interfacesslotvaluemd) objects
+
+#### Defined in
+
+[index.ts:46](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L46)
+
+___
+
+### UserResponsePayload
+
+Ƭ **UserResponsePayload**: \{ `type`: ``"text"`` ; `text`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"choice"`` ; `choiceId`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"structured"`` ; `context?`: [`Context`](#context)  } & [`StructuredRequest`](#interfacesstructuredrequestmd)
+
+The payload of the user response
+
+#### Defined in
+
+[index.ts:207](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L207)
+
+___
+
+### Response
+
+Ƭ **Response**: [`BotResponse`](#interfacesbotresponsemd) \| [`UserResponse`](#interfacesuserresponsemd) \| [`FailureMessage`](#interfacesfailuremessagemd)
+
+A response from the bot or the user.
+
+#### Defined in
+
+[index.ts:276](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L276)
+
+___
+
+### Time
+
+Ƭ **Time**: `number`
+
+The time value in milliseconds since midnight, January 1, 1970 UTC.
+
+#### Defined in
+
+[index.ts:281](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L281)
+
+___
+
+### Subscriber
+
+Ƭ **Subscriber**: (`response`: [`Response`](#response)[], `newResponse?`: [`Response`](#response)) => `void`
+
+The callback function for listening to all responses.
+
+#### Type declaration
+
+▸ (`response`, `newResponse?`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `response` | [`Response`](#response)[] |
+| `newResponse?` | [`Response`](#response) |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[index.ts:530](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L530)
+
+## Functions
+
+### shouldReinitialize
+
+▸ **shouldReinitialize**(`config1`, `config2`): `boolean`
+
+Helper method to decide when a new [Config](#interfacesconfigmd) requires creating a new [ConversationHandler](#interfacesconversationhandlermd) or whether the old `Config`'s
+`ConversationHandler` can be used.
+
+The order of configs doesn't matter.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config1` | [`Config`](#interfacesconfigmd) |
+| `config2` | [`Config`](#interfacesconfigmd) |
+
+#### Returns
+
+`boolean`
+
+true if `createConversation` should be called again
+
+#### Defined in
+
+[index.ts:541](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L541)
+
+___
+
+### default
+
+▸ **default**(`config`): [`ConversationHandler`](#interfacesconversationhandlermd)
+
+Call this to create a conversation handler.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | [`Config`](#interfacesconfigmd) |
+
+#### Returns
+
+[`ConversationHandler`](#interfacesconversationhandlermd)
+
+The [ConversationHandler](#interfacesconversationhandlermd) is a bundle of functions to interact with the conversation.
+
+#### Defined in
+
+[index.ts:556](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L556)
+
+___
+
+### promisify
+
+▸ **promisify**\<`T`\>(`fn`, `convo`, `timeout?`): (`payload`: `T`) => `Promise`\<[`Response`](#response) \| ``null``\>
+
+This package is intentionally designed with a subscription-based API as opposed to a promise-based one where each message corresponds to a single bot response, available asynchronously.
+
+If you need a promise-based wrapper, you can use the `promisify` helper available in the package:
+
+#### Type parameters
+
+| Name | Description |
+| :------ | :------ |
+| `T` | the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context` |
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `fn` | (`payload`: `T`) => `void` | `undefined` | the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.) |
+| `convo` | [`ConversationHandler`](#interfacesconversationhandlermd) | `undefined` | the `ConversationHandler` (from [createConversation](#default)) |
+| `timeout` | `number` | `10000` | the timeout in milliseconds |
+
+#### Returns
+
+`fn`
+
+A wrapped version of the function that returns a promise that resolves to the Conversation's next response.
+
+▸ (`payload`): `Promise`\<[`Response`](#response) \| ``null``\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `payload` | `T` |
+
+##### Returns
+
+`Promise`\<[`Response`](#response) \| ``null``\>
+
+**`Example`**
+
+```typescript
+import { createConversation, promisify } from "@nlxai/chat-core";
+
+const convo = createConversation(config);
+
+const sendTextWrapped = promisify(convo.sendText, convo);
+
+sendTextWrapped("Hello").then((response) => {
+  console.log(response);
+});
+```
+
+#### Defined in
+
+[index.ts:949](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L949)
+
+
+<a name="indexmd"></a>
+
+
+# Interfaces
+
+
+<a name="interfacesbotmessagemd"></a>
+
+## Interface: BotMessage
+
+A message from the bot, as well as any choices the user can make.
+
+### Properties
+
+#### nodeId
+
+• `Optional` **nodeId**: `string`
+
+The node id that this message is associated with.
+This is must be sent with a choice when the user is changing a previously sent choice.
+
+##### Defined in
+
+[index.ts:146](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L146)
+
+___
+
+#### text
+
+• **text**: `string`
+
+The body of the message. Show this to the user.
+
+##### Defined in
+
+[index.ts:150](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L150)
+
+___
+
+#### choices
+
+• **choices**: [`Choice`](#interfaceschoicemd)[]
+
+A selection of choices to show to the user. They may choose one of them.
+
+##### Defined in
+
+[index.ts:154](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L154)
+
+___
+
+#### selectedChoiceId
+
+• `Optional` **selectedChoiceId**: `string`
+
+After a choice has been made by the user, this will be updated locally to the selected choice id.
+This field is set locally and does not come from the bot.
+
+##### Defined in
+
+[index.ts:159](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L159)
+
+
+<a name="interfacesbotresponsemd"></a>
+
+## Interface: BotResponse
+
+A message from the bot
+
+See also:
+- [UserResponse](#interfacesuserresponsemd)
+- [FailureMessage](#interfacesfailuremessagemd)
+- [Response](#response)
+
+### Properties
+
+#### type
+
+• **type**: ``"bot"``
+
+The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
+
+##### Defined in
+
+[index.ts:60](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L60)
+
+___
+
+#### receivedAt
+
+• **receivedAt**: `number`
+
+When the response was received
+
+##### Defined in
+
+[index.ts:64](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L64)
+
+___
+
+#### payload
+
+• **payload**: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)
+
+The payload of the response
+
+##### Defined in
+
+[index.ts:68](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L68)
+
+
+<a name="interfacesbotresponsemetadatamd"></a>
+
+## Interface: BotResponseMetadata
+
+Global state about the current conversation
+as well as whether the client should poll for more bot responses.
+
+### Properties
+
+#### intentId
+
+• `Optional` **intentId**: `string`
+
+The conversation's intent
+
+##### Defined in
+
+[index.ts:114](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L114)
+
+___
+
+#### escalation
+
+• `Optional` **escalation**: `boolean`
+
+Whether the current conversation has been marked as incomprehension.
+
+##### Defined in
+
+[index.ts:118](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L118)
+
+___
+
+#### frustration
+
+• `Optional` **frustration**: `boolean`
+
+Whether the current conversation has been marked frustrated
+
+##### Defined in
+
+[index.ts:122](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L122)
+
+___
+
+#### incomprehension
+
+• `Optional` **incomprehension**: `boolean`
+
+Whether the current conversation has been marked as incomprehension.
+
+##### Defined in
+
+[index.ts:126](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L126)
+
+___
+
+#### hasPendingDataRequest
+
+• `Optional` **hasPendingDataRequest**: `boolean`
+
+Whether the client should poll for more bot responses.
+
+##### Defined in
+
+[index.ts:130](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L130)
+
+
+<a name="interfacesbotresponsepayloadmd"></a>
+
+## Interface: BotResponsePayload
+
+The payload of the bot response
+
+### Properties
+
+#### expirationTimestamp
+
+• `Optional` **expirationTimestamp**: `number`
+
+If there isn't some interaction by this time, the conversation will expire.
+
+##### Defined in
+
+[index.ts:78](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L78)
+
+___
+
+#### conversationId
+
+• `Optional` **conversationId**: `string`
+
+The active conversation ID. If not set, a new conversation will be started.
+
+##### Defined in
+
+[index.ts:82](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L82)
+
+___
+
+#### messages
+
+• **messages**: [`BotMessage`](#interfacesbotmessagemd)[]
+
+Any messages from the bot.
+
+##### Defined in
+
+[index.ts:86](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L86)
+
+___
+
+#### metadata
+
+• `Optional` **metadata**: [`BotResponseMetadata`](#interfacesbotresponsemetadatamd)
+
+Global state about the current conversation
+as well as whether the client should poll for more bot responses.
+
+##### Defined in
+
+[index.ts:91](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L91)
+
+___
+
+#### payload
+
+• `Optional` **payload**: `string`
+
+If configured, the [node's payload.](#add-functionality)
+
+##### Defined in
+
+[index.ts:95](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L95)
+
+___
+
+#### modalities
+
+• `Optional` **modalities**: `Record`\<`string`, `any`\>
+
+If configured, the node's modalities and their payloads.
+
+##### Defined in
+
+[index.ts:99](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L99)
+
+___
+
+#### context
+
+• `Optional` **context**: [`Context`](#context)
+
+If the node is set to send context, the whole context associated with the conversation.
+
+##### Defined in
+
+[index.ts:103](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L103)
+
+
+<a name="interfaceschoicemd"></a>
+
+## Interface: Choice
+
+A choices to show to the user.
+
+### Properties
+
+#### choiceId
+
+• **choiceId**: `string`
+
+`choiceId` is used by `sendChoice` to let the user choose this choice.
+
+##### Defined in
+
+[index.ts:169](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L169)
+
+___
+
+#### choiceText
+
+• **choiceText**: `string`
+
+The text of the choice
+
+##### Defined in
+
+[index.ts:173](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L173)
+
+___
+
+#### choicePayload
+
+• `Optional` **choicePayload**: `any`
+
+An optional, schemaless payload for the choice.
+
+##### Defined in
+
+[index.ts:177](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L177)
+
+
+<a name="interfaceschoicerequestmetadatamd"></a>
+
+## Interface: ChoiceRequestMetadata
+
+Helps link the choice to the specific message in the conversation.
+
+### Properties
+
+#### responseIndex
+
+• `Optional` **responseIndex**: `number`
+
+The index of the [Response](#response) associated with this choice.
+Setting this ensures that local state's `selectedChoiceId` on the corresponding [BotResponse](#interfacesbotresponsemd) is set.
+It is not sent to the bot.
+
+##### Defined in
+
+[index.ts:414](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L414)
+
+___
+
+#### messageIndex
+
+• `Optional` **messageIndex**: `number`
+
+The index of the [BotMessage](#interfacesbotmessagemd) associated with this choice.
+Setting this ensures that local state's `selectedChoiceId` on the corresponding [BotResponse](#interfacesbotresponsemd) is set.
+It is not sent to the bot.
+
+##### Defined in
+
+[index.ts:420](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L420)
+
+___
+
+#### nodeId
+
+• `Optional` **nodeId**: `string`
+
+Required if you want to change a choice that's already been sent.
+The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessagemd).
+
+##### Defined in
+
+[index.ts:425](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L425)
+
+
+<a name="interfacesconfigmd"></a>
+
+## Interface: Config
+
+The config to create a conversation.
+`botUrl` and
+
+### Properties
+
+#### botUrl
+
+• **botUrl**: `string`
+
+Fetch this from the bot's Deployment page.
+
+##### Defined in
+
+[index.ts:298](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L298)
+
+___
+
+#### conversationId
+
+• `Optional` **conversationId**: `string`
+
+The conversation ID. If not set, a new conversation will be started.
+
+##### Defined in
+
+[index.ts:302](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L302)
+
+___
+
+#### userId
+
+• `Optional` **userId**: `string`
+
+TODO I don't know what this is
+
+##### Defined in
+
+[index.ts:306](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L306)
+
+___
+
+#### responses
+
+• `Optional` **responses**: [`Response`](#response)[]
+
+Set this to initialize the chat with historical messages.
+
+##### Defined in
+
+[index.ts:310](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L310)
+
+___
+
+#### failureMessage
+
+• `Optional` **failureMessage**: `string`
+
+When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
+
+##### Defined in
+
+[index.ts:314](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L314)
+
+___
+
+#### headers
+
+• **headers**: `Record`\<`string`, `string`\> & \{ `nlx-api-key`: `string`  }
+
+Headers to forward to the NLX API.
+
+##### Defined in
+
+[index.ts:322](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L322)
+
+___
+
+#### languageCode
+
+• **languageCode**: `string`
+
+The language code to use for the bot. In the browser this can be fetched with `navigator.language`.
+If you don't have translations, hard-code this to the language code you support.
+
+##### Defined in
+
+[index.ts:332](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L332)
+
+___
+
+#### experimental
+
+• `Optional` **experimental**: `Object`
+
+Experimental settings
+
+##### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `channelType?` | `string` | Simulate alternative channel types |
+| `completeBotUrl?` | `boolean` | Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio |
+
+##### Defined in
+
+[index.ts:336](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L336)
+
+
+<a name="interfacesconversationhandlermd"></a>
+
+## Interface: ConversationHandler
+
+A bundle of functions to interact with a conversation, created by [createConversation](#default).
+
+### Properties
+
+#### sendText
+
+• **sendText**: (`text`: `string`, `context?`: [`Context`](#context)) => `void`
+
+Send user's message
+
+##### Type declaration
+
+▸ (`text`, `context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `text` | `string` | the user's message |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:437](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L437)
+
+___
+
+#### sendSlots
+
+• **sendSlots**: (`slots`: [`SlotsRecordOrArray`](#slotsrecordorarray), `context?`: [`Context`](#context)) => `void`
+
+Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settings) to the bot.
+
+##### Type declaration
+
+▸ (`slots`, `context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `slots` | [`SlotsRecordOrArray`](#slotsrecordorarray) | The slots to populate |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:443](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L443)
+
+___
+
+#### sendChoice
+
+• **sendChoice**: (`choiceId`: `string`, `context?`: [`Context`](#context), `metadata?`: [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd)) => `void`
+
+Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode/nodes#user-choice) from the bot.
+
+##### Type declaration
+
+▸ (`choiceId`, `context?`, `metadata?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `choiceId` | `string` | - |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| `metadata?` | [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd) | links the choice to the specific message and node in the conversation. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:450](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L450)
+
+___
+
+#### sendWelcomeIntent
+
+• **sendWelcomeIntent**: (`context?`: [`Context`](#context)) => `void`
+
+Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents). This should be done when the user starts interacting with the chat.
+
+##### Type declaration
+
+▸ (`context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:460](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L460)
+
+___
+
+#### sendIntent
+
+• **sendIntent**: (`intentId`: `string`, `context?`: [`Context`](#context)) => `void`
+
+Trigger a specific [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents).
+
+##### Type declaration
+
+▸ (`intentId`, `context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `intentId` | `string` | the intent to trigger. The id is the name under the Bot's _Intents_. |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:467](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L467)
+
+___
+
+#### sendStructured
+
+• **sendStructured**: (`request`: [`StructuredRequest`](#interfacesstructuredrequestmd), `context?`: [`Context`](#context)) => `void`
+
+Send a combination of choice, slots, and intent in one request.
+
+##### Type declaration
+
+▸ (`request`, `context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `request` | [`StructuredRequest`](#interfacesstructuredrequestmd) |  |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:474](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L474)
+
+___
+
+#### subscribe
+
+• **subscribe**: (`subscriber`: [`Subscriber`](#subscriber)) => () => `void`
+
+Subscribe a callback to the conversation. On subscribe, the subscriber will receive all of the Responses that the conversation has already received.
+
+##### Type declaration
+
+▸ (`subscriber`): () => `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `subscriber` | [`Subscriber`](#subscriber) | The callback to subscribe |
+
+###### Returns
+
+`fn`
+
+▸ (): `void`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:479](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L479)
+
+___
+
+#### unsubscribe
+
+• **unsubscribe**: (`subscriber`: [`Subscriber`](#subscriber)) => `void`
+
+Unsubscribe a callback from the conversation.
+
+##### Type declaration
+
+▸ (`subscriber`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `subscriber` | [`Subscriber`](#subscriber) | The callback to unsubscribe |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:484](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L484)
+
+___
+
+#### unsubscribeAll
+
+• **unsubscribeAll**: () => `void`
+
+Unsubscribe all callback from the conversation.
+
+##### Type declaration
+
+▸ (): `void`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:488](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L488)
+
+___
+
+#### currentConversationId
+
+• **currentConversationId**: () => `undefined` \| `string`
+
+Get the current conversation ID if it's set, or undefined if there is no conversation.
+
+##### Type declaration
+
+▸ (): `undefined` \| `string`
+
+###### Returns
+
+`undefined` \| `string`
+
+##### Defined in
+
+[index.ts:492](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L492)
+
+___
+
+#### reset
+
+• **reset**: (`options?`: \{ `clearResponses?`: `boolean`  }) => `void`
+
+Forces a new conversation. If `clearResponses` is set to true, will also clear historical responses passed to subscribers.
+Retains all existing subscribers.
+
+##### Type declaration
+
+▸ (`options?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `Object` | - |
+| `options.clearResponses?` | `boolean` | If set to true, will clear historical responses passed to subscribers. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:497](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L497)
+
+___
+
+#### destroy
+
+• **destroy**: () => `void`
+
+Removes all subscribers and, if using websockets, closes the connection.
+
+##### Type declaration
+
+▸ (): `void`
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:506](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L506)
+
+
+<a name="interfacesfailuremessagemd"></a>
+
+## Interface: FailureMessage
+
+A failure message is received when the NLX api is unreachable, or sends an unparsable response.
+
+### Properties
+
+#### type
+
+• **type**: ``"failure"``
+
+The type of the response is `"bot"` for bot and `"user"` for user.
+
+##### Defined in
+
+[index.ts:257](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L257)
+
+___
+
+#### payload
+
+• **payload**: `Object`
+
+The payload only includes an error message.
+
+##### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `text` | `string` | The error message is either the default, or the `failureMessage` set in the [Config](#interfacesconfigmd). |
+
+##### Defined in
+
+[index.ts:261](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L261)
+
+___
+
+#### receivedAt
+
+• **receivedAt**: `number`
+
+When the failure occurred.
+
+##### Defined in
+
+[index.ts:270](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L270)
+
+
+<a name="interfacesslotvaluemd"></a>
+
+## Interface: SlotValue
+
+Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
+
+An array of `SlotValue` objects is equivalent to a [SlotsRecord](#slotsrecord).
+
+### Properties
+
+#### slotId
+
+• **slotId**: `string`
+
+The attached slot's name
+
+##### Defined in
+
+[index.ts:21](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L21)
+
+___
+
+#### value
+
+• **value**: `any`
+
+Usually this will be a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
+for custom slots, this can optionally be the value's ID.
+
+##### Defined in
+
+[index.ts:26](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L26)
+
+
+<a name="interfacesstructuredrequestmd"></a>
+
+## Interface: StructuredRequest
+
+The body of `sendStructured`
+Includes a combination of choice, slots, and intent in one request.
+
+### Properties
+
+#### choiceId
+
+• `Optional` **choiceId**: `string`
+
+The `choiceId` is in the [BotResponse](#interfacesbotresponsemd)'s `.payload.messages[].choices[].choiceId` fields
+
+##### Defined in
+
+[index.ts:372](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L372)
+
+___
+
+#### nodeId
+
+• `Optional` **nodeId**: `string`
+
+Required if you want to change a choice that's already been sent.
+The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessagemd).
+
+##### Defined in
+
+[index.ts:377](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L377)
+
+___
+
+#### intentId
+
+• `Optional` **intentId**: `string`
+
+The intent to trigger. The `intentId` is the name under the Bot's _Intents_.
+
+##### Defined in
+
+[index.ts:381](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L381)
+
+___
+
+#### slots
+
+• `Optional` **slots**: [`SlotsRecordOrArray`](#slotsrecordorarray)
+
+The slots to populate
+
+##### Defined in
+
+[index.ts:385](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L385)
+
+
+<a name="interfacesuserresponsemd"></a>
+
+## Interface: UserResponse
+
+A message from the user
+
+See also:
+- [BotResponse](#interfacesbotresponsemd)
+- [FailureMessage](#interfacesfailuremessagemd)
+- [Response](#response)
+
+### Properties
+
+#### type
+
+• **type**: ``"user"``
+
+The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
+
+##### Defined in
+
+[index.ts:193](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L193)
+
+___
+
+#### receivedAt
+
+• **receivedAt**: `number`
+
+When the response was received
+
+##### Defined in
+
+[index.ts:197](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L197)
+
+___
+
+#### payload
+
+• **payload**: [`UserResponsePayload`](#userresponsepayload)
+
+The payload of the response
+
+##### Defined in
+
+[index.ts:201](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/chat-core/src/index.ts#L201)

--- a/packages/website/src/content/05-02-headless-api-reference.tsx
+++ b/packages/website/src/content/05-02-headless-api-reference.tsx
@@ -1,55 +1,7 @@
 import React from "react";
 import { PageTitle } from "../components/PageTitle";
 import { PageContent } from "../components/PageContent";
-import { coreSetupSnippet } from "../snippets";
-
-export const content = `
-The main method exported by this package is \`createConversation\`, which takes the bot configuration and returns a conversation handler.
-
-~~~js
-${coreSetupSnippet}
-~~~
-
-## Handler API
-
-The conversation handler has the following methods. For each send method, conversation context can be optionally specified as a second argument.
-
-### \`sendText: (text: string, context?: Record<string, unknown>) => void\`
-
-Send a simple text to your bot.
-
-### \`sendChoice: (choiceId: string, context?: Record<string, unknown>) => void\`
-
-Your bot may send a list of choices to choose from, each with a \`choiceText\` and a \`choiceId\` field. You can use \`choiceText\` as button labels, and include the \`choiceId\` in this method when sending responses.
-
-### \`sendSlots: (slots: Record<string, unknown>, context?: Record<string, unknown>) => void\`
-
-Send slot values directly through custom widgets such as interactive maps.
-
-### \`sendIntent: (intentId: string, context?: Record<string, unknown>) => void\`
-
-Trigger a specific intent. The most common use of this method is to show welcome messages by sending the \`NLX.Welcome\` intent.
-
-### \`sendStructured: (request: StructuredRequest, context?: Record<string, unknown>) => void\`
-
-Send a combination of choice, slots, and intent ID in one request.
-
-### \`subscribe: (subscriber: (responses: Response[], newResponse: Response | undefined) => void) => void\`
-
-Subscribe to the current state of messages whenever there is a change. The second argument returns the new response that is triggering the subscription, if there is one.
-
-### \`unsubscribe: (subscriber: (responses: Response[]) => void) => void\`
-
-Remove a subscription.
-
-### \`unsubscribeAll: () => void\`
-
-Remove all subscriptions.
-
-### \`reset: () => void\`
-
-Reset the conversation. This makes sure that information previously collected by your bot will not affect the logic of the conversation any longer.
-`;
+import content from "./06-03-multimodal-api-reference.md?raw";
 
 // initial eslint integration
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/website/src/content/05-02-headless-api-reference.tsx
+++ b/packages/website/src/content/05-02-headless-api-reference.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { PageTitle } from "../components/PageTitle";
 import { PageContent } from "../components/PageContent";
-import content from "./06-03-multimodal-api-reference.md?raw";
+import content from "./05-02-headless-api-reference.md?raw";
 
 // initial eslint integration
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/website/src/content/06-03-multimodal-api-reference.md
+++ b/packages/website/src/content/06-03-multimodal-api-reference.md
@@ -46,7 +46,7 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 #### Defined in
 
-[index.ts:23](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L23)
+[index.ts:23](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L23)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[index.ts:110](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L110)
+[index.ts:110](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L110)
 
 
 <a name="indexmd"></a>
@@ -115,7 +115,7 @@ sends a step to the voice bot
 
 ##### Defined in
 
-[index.ts:103](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L103)
+[index.ts:103](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L103)
 
 
 <a name="interfacesconfigmd"></a>
@@ -134,7 +134,7 @@ Initial configuration used when creating a journey manager
 
 ##### Defined in
 
-[index.ts:118](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L118)
+[index.ts:118](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L118)
 
 ___
 
@@ -146,7 +146,7 @@ the ID of the journey.
 
 ##### Defined in
 
-[index.ts:120](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L120)
+[index.ts:120](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L120)
 
 ___
 
@@ -158,7 +158,7 @@ your workspace id
 
 ##### Defined in
 
-[index.ts:123](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L123)
+[index.ts:123](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L123)
 
 ___
 
@@ -172,7 +172,7 @@ _Note: This must be dynamically set by the voice bot._
 
 ##### Defined in
 
-[index.ts:130](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L130)
+[index.ts:130](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L130)
 
 ___
 
@@ -186,7 +186,7 @@ In the browser may be fetched from `navigator.language`, or if the journey doesn
 
 ##### Defined in
 
-[index.ts:137](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L137)
+[index.ts:137](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L137)
 
 ___
 
@@ -198,4 +198,4 @@ set to true to help debug issues or errors. Defaults to false
 
 ##### Defined in
 
-[index.ts:140](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L140)
+[index.ts:140](https://github.com/nlxai/sdk/blob/9000e5617de1de2b189dac5dc77d80c0222fb982/packages/voice-compass/src/index.ts#L140)

--- a/packages/website/src/content/06-03-multimodal-api-reference.md
+++ b/packages/website/src/content/06-03-multimodal-api-reference.md
@@ -3,20 +3,10 @@
 
 # @nlxai/voice-compass
 
-## Table of contents
-
-### Interfaces
+## Interfaces
 
 - [Client](#interfacesclientmd)
 - [Config](#interfacesconfigmd)
-
-### Type Aliases
-
-- [Context](#context)
-
-### Functions
-
-- [create](#create)
 
 ## Setup
 
@@ -30,7 +20,7 @@ The starting point of the package. Call create to create a `VoiceCompass` client
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `options` | [`Config`](#interfacesconfigmd) | the configuration object |
+| `options` | [`Config`](#interfacesconfigmd) | configuration options for the client |
 
 #### Returns
 
@@ -56,7 +46,7 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 #### Defined in
 
-[index.ts:27](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L27)
+[index.ts:23](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L23)
 
 ___
 
@@ -66,36 +56,30 @@ ___
 
 Ƭ **Context**: `Record`\<`string`, `any`\>
 
-context to send back to the voice bot, for usage later in the intent.
+[context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent.
 
 #### Defined in
 
-[index.ts:115](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L115)
+[index.ts:110](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L110)
+
+
+<a name="indexmd"></a>
+
 
 # Interfaces
 
 
 <a name="interfacesclientmd"></a>
 
-[@nlxai/voice-compass](#readmemd) / Client
-
 ## Interface: Client
 
 The VoiceCompass client
-
-### Table of contents
-
-#### Properties
-
-- [sendStep](#sendstep)
 
 ### Properties
 
 #### sendStep
 
 • **sendStep**: (`stepId`: `string`, `context?`: [`Context`](#context)) => `Promise`\<`void`\>
-
-*
 
 **`Example`**
 
@@ -123,7 +107,7 @@ sends a step to the voice bot
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `stepId` | `string` | the next step to transition to. _Note: Must be a valid UUID_ |
-| `context?` | [`Context`](#context) | context to send back to the voice bot, for usage later in the intent. |
+| `context?` | [`Context`](#context) | [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent. |
 
 ###### Returns
 
@@ -131,27 +115,14 @@ sends a step to the voice bot
 
 ##### Defined in
 
-[index.ts:108](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L108)
+[index.ts:103](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L103)
 
 
 <a name="interfacesconfigmd"></a>
 
-[@nlxai/voice-compass](#readmemd) / Config
-
 ## Interface: Config
 
 Initial configuration used when creating a journey manager
-
-### Table of contents
-
-#### Properties
-
-- [apiKey](#apikey)
-- [journeyId](#journeyid)
-- [workspaceId](#workspaceid)
-- [conversationId](#conversationid)
-- [languageCode](#languagecode)
-- [debug](#debug)
 
 ### Properties
 
@@ -159,11 +130,11 @@ Initial configuration used when creating a journey manager
 
 • **apiKey**: `string`
 
-* the API key generated for the journey.  *
+* the API key generated for the journey.
 
 ##### Defined in
 
-[index.ts:123](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L123)
+[index.ts:118](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L118)
 
 ___
 
@@ -175,7 +146,7 @@ the ID of the journey.
 
 ##### Defined in
 
-[index.ts:125](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L125)
+[index.ts:120](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L120)
 
 ___
 
@@ -187,7 +158,7 @@ your workspace id
 
 ##### Defined in
 
-[index.ts:128](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L128)
+[index.ts:123](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L123)
 
 ___
 
@@ -201,7 +172,7 @@ _Note: This must be dynamically set by the voice bot._
 
 ##### Defined in
 
-[index.ts:134](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L134)
+[index.ts:130](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L130)
 
 ___
 
@@ -215,7 +186,7 @@ In the browser may be fetched from `navigator.language`, or if the journey doesn
 
 ##### Defined in
 
-[index.ts:140](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L140)
+[index.ts:137](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L137)
 
 ___
 
@@ -227,4 +198,4 @@ set to true to help debug issues or errors. Defaults to false
 
 ##### Defined in
 
-[index.ts:143](https://github.com/nlxai/sdk/blob/790d0f0/packages/voice-compass/src/index.ts#L143)
+[index.ts:140](https://github.com/nlxai/sdk/blob/05aef14f503ae87d487cac75223a950d4c5753ce/packages/voice-compass/src/index.ts#L140)


### PR DESCRIPTION
flesh out tsdoc for chat-core library

I'm unhappy with the formatting & ordering of the auto-generated docs.

Some options:
- stop using markdown rendering, and render typedoc natively to html on a different domain, e.g. `api.developers.nlx.ai`
- use typedoc to render to json, and write our own typedoc renderer to handle formatting & ordering ourself
- manually massage the markdown output until it looks more acceptable.