### PR TITLE
resolve noisey errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -856,15 +856,6 @@
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
       "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
     },
-    "node_modules/@docsearch/js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.0.tgz",
-      "integrity": "sha512-QujhqINEElrkIfKwyyyTfbsfMAYCkylInLYMRqHy7PHc8xTBQCow73tlo/Kc7oIwBrCLf0P3YhjlOeV4v8hevQ==",
-      "dependencies": {
-        "@docsearch/react": "3.6.0",
-        "preact": "^10.0.0"
-      }
-    },
     "node_modules/@docsearch/react": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
@@ -14879,6 +14870,7 @@
       "version": "10.20.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.1.tgz",
       "integrity": "sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -19864,7 +19856,8 @@
       "name": "@nlxai/website",
       "version": "0.1.0",
       "dependencies": {
-        "@docsearch/js": "^3.6.0",
+        "@docsearch/css": "^3.6.0",
+        "@docsearch/react": "^3.6.0",
         "@nlxai/chat-core": "*",
         "@nlxai/chat-react": "*",
         "@nlxai/chat-widget": "*",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run build:client && npm run build:static && npm run render-static",
     "build:client": "vite build --outDir dist/client",
-    "build:static": "vite build --ssr src/entry-server.tsx --outDir dist/static",
+    "build:static": "vite build --ssr src/static-renderer.tsx --outDir dist/static",
     "dev": "vite --force",
     "render-static": "tsx render-static.ts",
     "lint:check": "eslint src/ --ext .ts,.tsx,.js,.jsx,.mdx --max-warnings 0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -16,7 +16,8 @@
     "test": "npm run build && scripts/check-for-broken-links.sh"
   },
   "dependencies": {
-    "@docsearch/js": "^3.6.0",
+    "@docsearch/css": "^3.6.0",
+    "@docsearch/react": "^3.6.0",
     "@nlxai/chat-core": "*",
     "@nlxai/chat-react": "*",
     "@nlxai/chat-widget": "*",

--- a/packages/website/render-static.ts
+++ b/packages/website/render-static.ts
@@ -2,11 +2,13 @@ import fs from "node:fs/promises";
 import { exit } from "node:process";
 import { createServer } from "vite";
 import { dirname } from "node:path";
-// @ts-expect-error we need to build this before usage to ensure cache-busted assets are included, but building right now doesn't build .d.ts files
-import { render as untypedRender } from "./dist/static/entry-server.js";
 import { create } from "xmlbuilder2";
-import { XMLBuilder } from "xmlbuilder2/lib/interfaces.js";
+import type { XMLBuilder } from "xmlbuilder2/lib/interfaces";
+// @ts-expect-error we need to build this before usage to ensure cache-busted assets are included, but building right now doesn't build .d.ts files
+import { render as untypedRender } from "./dist/static/static-renderer.js";
 const render: (url: string) => string = untypedRender;
+
+/* this script statically renders the website, and generates a sitemap */
 
 const server = await createServer({
   server: { middlewareMode: true },

--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -2,8 +2,7 @@ import React, { type FC } from "react";
 import { Link } from "react-router-dom";
 import { Logo } from "./Logo";
 
-// this funky import is to workaround https://github.com/algolia/docsearch/pull/2117
-import * as DocSearchReact from "@docsearch/react";
+import { DocSearch } from "@docsearch/react";
 import "@docsearch/css";
 
 export const Header: FC<{
@@ -43,16 +42,11 @@ export const Header: FC<{
         <span className="block" aria-label="Home page">
           Developers
         </span>
-        {
-          // I couldn't get DocSearch to properly render statically, so this is a bit of a hacky workaround
-          import.meta.env.SSR ? null : (
-            <DocSearchReact.DocSearch
-              appId={import.meta.env.VITE_ALGOLIA_APP_ID}
-              indexName={import.meta.env.VITE_ALGOLIA_INDEX_NAME}
-              apiKey={import.meta.env.VITE_ALGOLIA_API_KEY}
-            />
-          )
-        }
+        <DocSearch
+          appId={import.meta.env.VITE_ALGOLIA_APP_ID}
+          indexName={import.meta.env.VITE_ALGOLIA_INDEX_NAME}
+          apiKey={import.meta.env.VITE_ALGOLIA_API_KEY}
+        />
       </Link>
     </div>
     <div className="relative flex basis-0 justify-end gap-6 sm:gap-8 md:flex-grow">

--- a/packages/website/src/custom-components/Disclaimer.tsx
+++ b/packages/website/src/custom-components/Disclaimer.tsx
@@ -14,12 +14,13 @@ export const Disclaimer = () => {
     <div className="chat-disclaimer">
       ${status === "pending" &&
       html`
-        <p>
+        <p key="pending">
           In order to enhance your experience in this chat, we would like to
           temporarily store personal data according to our${" "}
           <a>privacy policy</a>.
         </p>
         <button
+          key="pending-accepted-button"
           onClick=${() => {
             setStatus("accepted");
           }}
@@ -27,6 +28,7 @@ export const Disclaimer = () => {
           Accept
         </button>
         <button
+          key="pending-denied-button"
           onClick=${() => {
             setStatus("denied");
           }}

--- a/packages/website/src/custom-components/Disclaimer.tsx
+++ b/packages/website/src/custom-components/Disclaimer.tsx
@@ -8,45 +8,45 @@ const html = htm.bind(createElement);
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const Disclaimer = () => {
   const [status, setStatus] = useState<"pending" | "accepted" | "denied">(
-    "pending"
+    "pending",
   );
   return html`
     <div className="chat-disclaimer">
       ${status === "pending" &&
-        html`
-          <p>
-            In order to enhance your experience in this chat, we would like to
-            temporarily store personal data according to our${" "}
-            <a>privacy policy</a>.
-          </p>
-          <button
-            onClick=${() => {
-              setStatus("accepted");
-            }}
-          >
-            Accept
-          </button>
-          <button
-            onClick=${() => {
-              setStatus("denied");
-            }}
-          >
-            Deny
-          </button>
-        `}
+      html`
+        <p>
+          In order to enhance your experience in this chat, we would like to
+          temporarily store personal data according to our${" "}
+          <a>privacy policy</a>.
+        </p>
+        <button
+          onClick=${() => {
+            setStatus("accepted");
+          }}
+        >
+          Accept
+        </button>
+        <button
+          onClick=${() => {
+            setStatus("denied");
+          }}
+        >
+          Deny
+        </button>
+      `}
       ${status === "accepted" &&
-        html`
-          <p>
-            As requested, we might store certain personal or device identifiers
-            to enhance your experience on this chat.
-          </p>
-        `}
+      html`
+        <p>
+          As requested, we might store certain personal or device identifiers to
+          enhance your experience on this chat.
+        </p>
+      `}
       ${status === "denied" &&
-        html`
-          <p>
-            As requested, we will not store personal information in this chat.
-          </p>
-        `}
+      html`
+        <p>
+          As requested, we will not store personal information in this chat.
+        </p>
+      `}
     </div>
   `;
 };

--- a/packages/website/src/entry-client.tsx
+++ b/packages/website/src/entry-client.tsx
@@ -1,14 +1,19 @@
 import "./index.css";
 import React from "react";
-import ReactDOM from "react-dom/client";
+import ReactDOM, { createRoot } from "react-dom/client";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
 
-ReactDOM.hydrateRoot(
-  document.getElementById("app") as Element,
+const contents = (
   <React.StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </React.StrictMode>,
+  </React.StrictMode>
 );
+
+if (import.meta.env.DEV) {
+  createRoot(document.getElementById("app") as Element).render(contents);
+} else {
+  ReactDOM.hydrateRoot(document.getElementById("app") as Element, contents);
+}

--- a/packages/website/src/static-renderer.tsx
+++ b/packages/website/src/static-renderer.tsx
@@ -3,6 +3,14 @@ import ReactDOMServer from "react-dom/server";
 import App from "./App";
 import { StaticRouter } from "react-router-dom/server";
 
+/*
+ * this file is run through the vite build system, doing
+ * bundling, transpiling, minification, etc.
+ *
+ * After it's bundled, it's loaded by `render-static.ts`
+ * and used to pre-render the website.
+ */
+
 export function render(url: string): string {
   return ReactDOMServer.renderToString(
     <React.StrictMode>

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -13,5 +13,5 @@
     "target": "esnext",
     "types": ["vite/client", "node"]
   },
-  "include": ["src/**/*", "dist/static/entry-server.js", "render-static.ts"]
+  "include": ["src/**/*", "dist/static/static-renderer.js", "render-static.ts"]
 }

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
   build: {
     commonjsOptions: {
       include: [/node_modules/, /chat-core/, /chat-react/, /chat-widget/],
-      transformMixedEsModules: true,
     },
   },
   ssr: {

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
   build: {
     commonjsOptions: {
       include: [/node_modules/, /chat-core/, /chat-react/, /chat-widget/],
+      transformMixedEsModules: true,
     },
+  },
+  ssr: {
+    // the way algolia bundles its code, without setting `type:module` breaks the SSR build.
+    // bundling this (as is done in the client) resolves the issue.
+    // this works around https://github.com/algolia/docsearch/pull/2117
+    noExternal: [/docsearch/, /algolia/],
   },
 });


### PR DESCRIPTION
before resolving other errors, I want the baseline number of errors to be zero.

this PR resolves...
- errors in dev about not hydrating (because dev doesn't use static rendering or a server)
- errors on both because of keying (I don't exactly know why this happened but I made react happy anyways)
- errors in production because of failed hydration (because the SSR version didn't render DocSearch so the doms were different)