### PR TITLE
Forces chat widget to light mode

### DIFF
--- a/packages/chat-widget/src/ui/components.tsx
+++ b/packages/chat-widget/src/ui/components.tsx
@@ -142,6 +142,7 @@ export const Container = styled.div<{
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.3);
   background-color: ${(props) => props.theme.white};
   z-index: ${constants.largeZIndex};
+  color-scheme: only light;
 
   @media screen and (min-width: 360px) {
     & {


### PR DESCRIPTION
![image_720](https://github.com/nlxai/sdk/assets/161446658/b5d429cd-a2d5-413e-abed-42d7e5bda01d)


Fixes the above issue caused when the browser is switched to dark mode. The root cause is of course that the input doesn't have an explicit color set, but I'd rather not mess with that at the moment, since it's not clear to me that it would work with the background the users can control, and this way it can be overriden with CSS if need be.