### PR TITLE
Add trigger highlights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1526,6 +1526,28 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+      "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
+      "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -19901,6 +19923,7 @@
       "version": "0.1.27",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/dom": "^1.6.5",
         "@nlxai/multimodal": "^0.1.20",
         "@testing-library/dom": "^10.1.0",
         "ramda": "^0.29.1",

--- a/packages/journey-manager/package.json
+++ b/packages/journey-manager/package.json
@@ -42,6 +42,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.6.5",
     "@nlxai/multimodal": "^0.1.20",
     "@testing-library/dom": "^10.1.0",
     "ramda": "^0.29.1",

--- a/packages/website/src/content/04-03-react-api-reference.md
+++ b/packages/website/src/content/04-03-react-api-reference.md
@@ -36,7 +36,7 @@ the hook object containing the chat state and methods.
 
 #### Defined in
 
-[index.ts:52](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-react/src/index.ts#L52)
+[index.ts:52](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-react/src/index.ts#L52)
 
 
 <a name="indexmd"></a>
@@ -63,7 +63,7 @@ handled by the hook automatically.
 
 ##### Defined in
 
-[index.ts:21](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-react/src/index.ts#L21)
+[index.ts:21](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-react/src/index.ts#L21)
 
 ___
 
@@ -77,7 +77,7 @@ Using this field is optional and you can hold input state separately.
 
 ##### Defined in
 
-[index.ts:27](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-react/src/index.ts#L27)
+[index.ts:27](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-react/src/index.ts#L27)
 
 ___
 
@@ -103,7 +103,7 @@ Modify the value of the chat input field.
 
 ##### Defined in
 
-[index.ts:32](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-react/src/index.ts#L32)
+[index.ts:32](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-react/src/index.ts#L32)
 
 ___
 
@@ -117,7 +117,7 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 ##### Defined in
 
-[index.ts:38](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-react/src/index.ts#L38)
+[index.ts:38](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-react/src/index.ts#L38)
 
 ___
 
@@ -130,4 +130,4 @@ bubble with loading dots.
 
 ##### Defined in
 
-[index.ts:43](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-react/src/index.ts#L43)
+[index.ts:43](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-react/src/index.ts#L43)

--- a/packages/website/src/content/04-04-preact-api-reference.md
+++ b/packages/website/src/content/04-04-preact-api-reference.md
@@ -36,7 +36,7 @@ the hook object containing the chat state and methods.
 
 #### Defined in
 
-[index.ts:52](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-preact/src/index.ts#L52)
+[index.ts:52](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-preact/src/index.ts#L52)
 
 
 <a name="indexmd"></a>
@@ -63,7 +63,7 @@ handled by the hook automatically.
 
 ##### Defined in
 
-[index.ts:21](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-preact/src/index.ts#L21)
+[index.ts:21](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-preact/src/index.ts#L21)
 
 ___
 
@@ -77,7 +77,7 @@ Using this field is optional and you can hold input state separately.
 
 ##### Defined in
 
-[index.ts:27](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-preact/src/index.ts#L27)
+[index.ts:27](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-preact/src/index.ts#L27)
 
 ___
 
@@ -103,7 +103,7 @@ Modify the value of the chat input field.
 
 ##### Defined in
 
-[index.ts:32](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-preact/src/index.ts#L32)
+[index.ts:32](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-preact/src/index.ts#L32)
 
 ___
 
@@ -117,7 +117,7 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 ##### Defined in
 
-[index.ts:38](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-preact/src/index.ts#L38)
+[index.ts:38](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-preact/src/index.ts#L38)
 
 ___
 
@@ -130,4 +130,4 @@ bubble with loading dots.
 
 ##### Defined in
 
-[index.ts:43](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-preact/src/index.ts#L43)
+[index.ts:43](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-preact/src/index.ts#L43)

--- a/packages/website/src/content/05-02-headless-api-reference.md
+++ b/packages/website/src/content/05-02-headless-api-reference.md
@@ -31,7 +31,7 @@ full page refreshes.
 
 #### Defined in
 
-[packages/chat-widget/src/props.ts:45](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L45)
+[packages/chat-widget/src/props.ts:45](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L45)
 
 ___
 
@@ -44,7 +44,7 @@ See: https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode
 
 #### Defined in
 
-[packages/chat-widget/src/props.ts:51](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L51)
+[packages/chat-widget/src/props.ts:51](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L51)
 
 ## Variables
 
@@ -56,7 +56,7 @@ the default theme
 
 #### Defined in
 
-[packages/chat-widget/src/ui/constants.ts:16](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/ui/constants.ts#L16)
+[packages/chat-widget/src/ui/constants.ts:16](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/ui/constants.ts#L16)
 
 ## Functions
 
@@ -80,7 +80,7 @@ the WidgetInstance to script widget behavior.
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:102](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L102)
+[packages/chat-widget/src/index.tsx:102](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L102)
 
 ___
 
@@ -102,7 +102,7 @@ Clears stored session history.
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:300](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L300)
+[packages/chat-widget/src/index.tsx:300](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L300)
 
 ___
 
@@ -122,7 +122,7 @@ the ConversationHandler if the widget has been created and its conversation has 
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:368](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L368)
+[packages/chat-widget/src/index.tsx:368](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L368)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:372](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L372)
+[packages/chat-widget/src/index.tsx:372](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L372)
 
 
 <a name="indexmd"></a>
@@ -171,7 +171,7 @@ The text content of the nudge. Markdown is supported.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:73](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L73)
+[packages/chat-widget/src/props.ts:73](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L73)
 
 ___
 
@@ -184,7 +184,7 @@ Defaults to 3000 (3s) if not set.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:78](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L78)
+[packages/chat-widget/src/props.ts:78](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L78)
 
 ___
 
@@ -197,7 +197,7 @@ Defaults to 20000 (20s) if not set.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:83](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L83)
+[packages/chat-widget/src/props.ts:83](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L83)
 
 
 <a name="interfacespropsmd"></a>
@@ -216,7 +216,7 @@ The configuration to create a conversation.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:93](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L93)
+[packages/chat-widget/src/props.ts:93](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L93)
 
 ___
 
@@ -228,7 +228,7 @@ The theme to apply to the chat widget.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:97](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L97)
+[packages/chat-widget/src/props.ts:97](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L97)
 
 ___
 
@@ -240,7 +240,7 @@ How to configure the title bar. When missing, the widget will not have a title b
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:101](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L101)
+[packages/chat-widget/src/props.ts:101](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L101)
 
 ___
 
@@ -252,7 +252,7 @@ If you want a custom chat icon, set this to the URL of an image to use.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:105](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L105)
+[packages/chat-widget/src/props.ts:105](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L105)
 
 ___
 
@@ -264,7 +264,7 @@ An optional [Nudge](#interfacesnudgemd) configuration object.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:109](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L109)
+[packages/chat-widget/src/props.ts:109](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L109)
 
 ___
 
@@ -276,7 +276,7 @@ The placeholder in the input field. When not set, the default placeholder is "Ty
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:113](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L113)
+[packages/chat-widget/src/props.ts:113](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L113)
 
 ___
 
@@ -288,7 +288,7 @@ A message to display to the user while the bot is still processing the previous 
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:117](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L117)
+[packages/chat-widget/src/props.ts:117](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L117)
 
 ___
 
@@ -300,7 +300,7 @@ How long to wait, in milliseconds, before the loader message is displayed. Defau
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:121](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L121)
+[packages/chat-widget/src/props.ts:121](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L121)
 
 ___
 
@@ -312,7 +312,7 @@ If set to true, previously selected choices in the chat can be changed.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:125](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L125)
+[packages/chat-widget/src/props.ts:125](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L125)
 
 ___
 
@@ -324,7 +324,7 @@ When set, chat history & conversation will be stored in the browser.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:129](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L129)
+[packages/chat-widget/src/props.ts:129](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L129)
 
 ___
 
@@ -350,7 +350,7 @@ Optional callback to be called when the chat is expanded.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:133](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L133)
+[packages/chat-widget/src/props.ts:133](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L133)
 
 ___
 
@@ -376,7 +376,7 @@ Optional callback to be called when the chat is collapsed. This is also called w
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:137](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L137)
+[packages/chat-widget/src/props.ts:137](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L137)
 
 ___
 
@@ -396,7 +396,7 @@ Optional callback to be called when the chat is closed via the close button.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:141](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L141)
+[packages/chat-widget/src/props.ts:141](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L141)
 
 ___
 
@@ -422,7 +422,7 @@ Optional callback to be called when the nudge element is closed explicitly by th
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:145](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L145)
+[packages/chat-widget/src/props.ts:145](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L145)
 
 ___
 
@@ -435,7 +435,7 @@ See: https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:151](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L151)
+[packages/chat-widget/src/props.ts:151](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L151)
 
 
 <a name="interfacesthememd"></a>
@@ -455,7 +455,7 @@ Primary color for interactive UI elements like buttons
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:7](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L7)
+[packages/chat-widget/src/theme.ts:7](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L7)
 
 ___
 
@@ -467,7 +467,7 @@ Background color for the dark chat bubbles (sent by the user)
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:9](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L9)
+[packages/chat-widget/src/theme.ts:9](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L9)
 
 ___
 
@@ -479,7 +479,7 @@ Background color for the light chat bubbles (sent by the bot)
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:11](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L11)
+[packages/chat-widget/src/theme.ts:11](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L11)
 
 ___
 
@@ -491,7 +491,7 @@ Customized shade of white
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:13](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L13)
+[packages/chat-widget/src/theme.ts:13](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L13)
 
 ___
 
@@ -503,7 +503,7 @@ Widget font family
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:15](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L15)
+[packages/chat-widget/src/theme.ts:15](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L15)
 
 ___
 
@@ -515,7 +515,7 @@ Main spacing unit
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:17](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L17)
+[packages/chat-widget/src/theme.ts:17](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L17)
 
 ___
 
@@ -527,7 +527,7 @@ Chat border radius
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:19](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L19)
+[packages/chat-widget/src/theme.ts:19](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L19)
 
 ___
 
@@ -539,7 +539,7 @@ Max height of the chat window
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:21](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/theme.ts#L21)
+[packages/chat-widget/src/theme.ts:21](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/theme.ts#L21)
 
 
 <a name="interfacestitlebarmd"></a>
@@ -559,7 +559,7 @@ Optional URL to a logo image to be displayed on to the left of the title.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:13](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L13)
+[packages/chat-widget/src/props.ts:13](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L13)
 
 ___
 
@@ -571,7 +571,7 @@ The title string.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:17](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L17)
+[packages/chat-widget/src/props.ts:17](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L17)
 
 ___
 
@@ -584,7 +584,7 @@ Pressing the collapse button will hide the chat overlay but keep it active.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:22](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L22)
+[packages/chat-widget/src/props.ts:22](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L22)
 
 ___
 
@@ -600,7 +600,7 @@ Pressing the close button will
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:30](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/props.ts#L30)
+[packages/chat-widget/src/props.ts:30](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/props.ts#L30)
 
 
 <a name="interfaceswidgetinstancemd"></a>
@@ -628,7 +628,7 @@ If you want to additionally clear a stored session, explicitly call [clearSessio
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:62](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L62)
+[packages/chat-widget/src/index.tsx:62](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L62)
 
 ___
 
@@ -648,7 +648,7 @@ Expand the widget and call the `onExpand` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:66](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L66)
+[packages/chat-widget/src/index.tsx:66](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L66)
 
 ___
 
@@ -668,7 +668,7 @@ Collapse the widget and call the `onCollapse` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:70](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L70)
+[packages/chat-widget/src/index.tsx:70](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L70)
 
 ___
 
@@ -690,7 +690,7 @@ See: https://developers.nlx.ai/headless-api-reference#interfacesconversationhand
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:76](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L76)
+[packages/chat-widget/src/index.tsx:76](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L76)
 
 
 <a name="interfaceswidgetrefmd"></a>
@@ -717,7 +717,7 @@ Expand the widget and call the `onExpand` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:86](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L86)
+[packages/chat-widget/src/index.tsx:86](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L86)
 
 ___
 
@@ -737,7 +737,7 @@ Collapse the widget and call the `onCollapse` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:90](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L90)
+[packages/chat-widget/src/index.tsx:90](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L90)
 
 ___
 
@@ -749,4 +749,4 @@ the ConversationHandler for the widget.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:94](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/chat-widget/src/index.tsx#L94)
+[packages/chat-widget/src/index.tsx:94](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/chat-widget/src/index.tsx#L94)

--- a/packages/website/src/content/06-03-multimodal-api-reference.md
+++ b/packages/website/src/content/06-03-multimodal-api-reference.md
@@ -46,7 +46,7 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 #### Defined in
 
-index.ts:26
+[index.ts:26](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L26)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-index.ts:113
+[index.ts:113](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L113)
 
 
 <a name="indexmd"></a>
@@ -115,7 +115,7 @@ sends a step to the voice bot
 
 ##### Defined in
 
-index.ts:106
+[index.ts:106](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L106)
 
 
 <a name="interfacesconfigmd"></a>
@@ -134,7 +134,7 @@ Initial configuration used when creating a journey manager
 
 ##### Defined in
 
-index.ts:121
+[index.ts:121](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L121)
 
 ___
 
@@ -146,7 +146,7 @@ the ID of the journey.
 
 ##### Defined in
 
-index.ts:123
+[index.ts:123](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L123)
 
 ___
 
@@ -158,7 +158,7 @@ your workspace id
 
 ##### Defined in
 
-index.ts:126
+[index.ts:126](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L126)
 
 ___
 
@@ -172,7 +172,7 @@ _Note: This must be dynamically set by the voice bot._
 
 ##### Defined in
 
-index.ts:133
+[index.ts:133](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L133)
 
 ___
 
@@ -184,7 +184,7 @@ the user's language code, consistent with the language codes defined on the jour
 
 ##### Defined in
 
-index.ts:138
+[index.ts:138](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L138)
 
 ___
 
@@ -196,4 +196,4 @@ set to true to help debug issues or errors. Defaults to false
 
 ##### Defined in
 
-index.ts:141
+[index.ts:141](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/multimodal/src/index.ts#L141)

--- a/packages/website/src/content/07-02-journey-manager-api-reference.md
+++ b/packages/website/src/content/07-02-journey-manager-api-reference.md
@@ -29,7 +29,7 @@ Step ID
 
 #### Defined in
 
-[index.ts:22](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L22)
+[index.ts:22](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L22)
 
 ___
 
@@ -41,7 +41,7 @@ A record of triggers
 
 #### Defined in
 
-[index.ts:64](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L64)
+[index.ts:64](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L64)
 
 ___
 
@@ -53,7 +53,7 @@ Active trigger event type.
 
 #### Defined in
 
-[index.ts:143](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L143)
+[index.ts:143](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L143)
 
 ___
 
@@ -65,7 +65,7 @@ Matching method
 
 #### Defined in
 
-[queries.ts:10](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L10)
+[queries.ts:10](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L10)
 
 ## Functions
 
@@ -89,7 +89,7 @@ an object containing a teardown function and the multimodal client.
 
 #### Defined in
 
-[index.ts:213](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L213)
+[index.ts:209](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L209)
 
 
 <a name="indexmd"></a>
@@ -114,7 +114,7 @@ The trigger associated with the elements.
 
 ##### Defined in
 
-[index.ts:150](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L150)
+[index.ts:150](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L150)
 
 ___
 
@@ -126,7 +126,7 @@ The matched elements
 
 ##### Defined in
 
-[index.ts:152](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L152)
+[index.ts:152](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L152)
 
 
 <a name="interfacesclickstepmd"></a>
@@ -145,7 +145,7 @@ Step ID
 
 ##### Defined in
 
-[index.ts:79](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L79)
+[index.ts:79](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L79)
 
 ___
 
@@ -157,7 +157,7 @@ Element query
 
 ##### Defined in
 
-[index.ts:83](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L83)
+[index.ts:83](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L83)
 
 ___
 
@@ -169,7 +169,7 @@ Controls whether the step should only trigger the first time it is clicked, or o
 
 ##### Defined in
 
-[index.ts:87](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L87)
+[index.ts:87](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L87)
 
 ___
 
@@ -181,7 +181,7 @@ URL condition for the click
 
 ##### Defined in
 
-[index.ts:91](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L91)
+[index.ts:91](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L91)
 
 
 <a name="interfacesencodedquerymd"></a>
@@ -200,7 +200,7 @@ Query name
 
 ##### Defined in
 
-[queries.ts:60](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L60)
+[queries.ts:60](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L60)
 
 ___
 
@@ -212,7 +212,7 @@ Query target
 
 ##### Defined in
 
-[queries.ts:64](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L64)
+[queries.ts:64](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L64)
 
 ___
 
@@ -224,7 +224,7 @@ Query options
 
 ##### Defined in
 
-[queries.ts:68](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L68)
+[queries.ts:68](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L68)
 
 ___
 
@@ -236,7 +236,7 @@ Query parent
 
 ##### Defined in
 
-[queries.ts:72](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L72)
+[queries.ts:72](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L72)
 
 
 <a name="interfacespartialthememd"></a>
@@ -255,7 +255,7 @@ UI colors
 
 ##### Defined in
 
-[ui.ts:39](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L39)
+[ui.ts:43](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L43)
 
 ___
 
@@ -267,7 +267,7 @@ Font family
 
 ##### Defined in
 
-[ui.ts:43](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L43)
+[ui.ts:47](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L47)
 
 
 <a name="interfacesquerymd"></a>
@@ -286,7 +286,7 @@ Query name
 
 ##### Defined in
 
-[queries.ts:28](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L28)
+[queries.ts:28](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L28)
 
 ___
 
@@ -298,7 +298,7 @@ Query arguments
 
 ##### Defined in
 
-[queries.ts:32](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L32)
+[queries.ts:32](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L32)
 
 ___
 
@@ -310,7 +310,7 @@ Parent query
 
 ##### Defined in
 
-[queries.ts:36](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L36)
+[queries.ts:36](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L36)
 
 
 <a name="interfacesrunoutputmd"></a>
@@ -337,33 +337,7 @@ Stop running the journey, removing all event listeners
 
 ##### Defined in
 
-[index.ts:162](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L162)
-
-___
-
-#### findActiveTriggers
-
-• **findActiveTriggers**: (`eventType`: ``"click"``) => [`ActiveTrigger`](#interfacesactivetriggermd)[]
-
-Find active triggers on the page
-
-##### Type declaration
-
-▸ (`eventType`): [`ActiveTrigger`](#interfacesactivetriggermd)[]
-
-###### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `eventType` | ``"click"`` |
-
-###### Returns
-
-[`ActiveTrigger`](#interfacesactivetriggermd)[]
-
-##### Defined in
-
-[index.ts:166](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L166)
+[index.ts:162](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L162)
 
 ___
 
@@ -375,7 +349,7 @@ The regular multimodal SDK client
 
 ##### Defined in
 
-[index.ts:170](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L170)
+[index.ts:166](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L166)
 
 
 <a name="interfacesrunpropsmd"></a>
@@ -394,7 +368,7 @@ The regular multimodal configuration
 
 ##### Defined in
 
-[index.ts:180](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L180)
+[index.ts:176](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L176)
 
 ___
 
@@ -406,7 +380,7 @@ UI configuration
 
 ##### Defined in
 
-[index.ts:184](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L184)
+[index.ts:180](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L180)
 
 ___
 
@@ -418,7 +392,7 @@ The triggers dictionary, downloaded from the Dialog Studio desktop app
 
 ##### Defined in
 
-[index.ts:188](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L188)
+[index.ts:184](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L184)
 
 ___
 
@@ -444,7 +418,7 @@ Digression detection callback
 
 ##### Defined in
 
-[index.ts:192](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L192)
+[index.ts:188](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L188)
 
 
 <a name="interfacesserializedregexmd"></a>
@@ -463,7 +437,7 @@ Regex body
 
 ##### Defined in
 
-[queries.ts:46](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L46)
+[queries.ts:46](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L46)
 
 ___
 
@@ -475,7 +449,7 @@ Regex flags
 
 ##### Defined in
 
-[queries.ts:50](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/queries.ts#L50)
+[queries.ts:50](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/queries.ts#L50)
 
 
 <a name="interfacesthememd"></a>
@@ -494,7 +468,7 @@ UI colors
 
 ##### Defined in
 
-[ui.ts:25](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L25)
+[ui.ts:29](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L29)
 
 ___
 
@@ -506,7 +480,7 @@ Font family
 
 ##### Defined in
 
-[ui.ts:29](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L29)
+[ui.ts:33](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L33)
 
 
 <a name="interfacesthemecolorsmd"></a>
@@ -525,7 +499,7 @@ Primary color
 
 ##### Defined in
 
-[ui.ts:11](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L11)
+[ui.ts:11](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L11)
 
 ___
 
@@ -537,7 +511,19 @@ Primary color on hover
 
 ##### Defined in
 
-[ui.ts:15](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L15)
+[ui.ts:15](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L15)
+
+___
+
+#### highlight
+
+• **highlight**: `string`
+
+Color for trigger highlights
+
+##### Defined in
+
+[ui.ts:19](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L19)
 
 
 <a name="interfacestriggermd"></a>
@@ -556,7 +542,7 @@ Event
 
 ##### Defined in
 
-[index.ts:46](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L46)
+[index.ts:46](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L46)
 
 ___
 
@@ -568,7 +554,7 @@ A query identifying the element
 
 ##### Defined in
 
-[index.ts:50](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L50)
+[index.ts:50](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L50)
 
 ___
 
@@ -580,7 +566,7 @@ A flag specifying whether the trigger should only fire a single time
 
 ##### Defined in
 
-[index.ts:54](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L54)
+[index.ts:54](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L54)
 
 ___
 
@@ -592,7 +578,7 @@ URL condition
 
 ##### Defined in
 
-[index.ts:58](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L58)
+[index.ts:58](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L58)
 
 
 <a name="interfacesuiconfigmd"></a>
@@ -611,7 +597,7 @@ Drawer title
 
 ##### Defined in
 
-[ui.ts:53](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L53)
+[ui.ts:57](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L57)
 
 ___
 
@@ -623,7 +609,19 @@ Drawer subtitle
 
 ##### Defined in
 
-[ui.ts:57](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L57)
+[ui.ts:61](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L61)
+
+___
+
+#### highlights
+
+• `Optional` **highlights**: `boolean`
+
+Render highlights
+
+##### Defined in
+
+[ui.ts:65](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L65)
 
 ___
 
@@ -635,7 +633,7 @@ UI theme
 
 ##### Defined in
 
-[ui.ts:61](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L61)
+[ui.ts:69](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L69)
 
 ___
 
@@ -647,7 +645,7 @@ Escalation step ID
 
 ##### Defined in
 
-[ui.ts:65](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L65)
+[ui.ts:73](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L73)
 
 ___
 
@@ -659,7 +657,7 @@ End step ID
 
 ##### Defined in
 
-[ui.ts:69](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/ui.ts#L69)
+[ui.ts:77](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/ui.ts#L77)
 
 
 <a name="interfacesurlconditionmd"></a>
@@ -678,7 +676,7 @@ Condition operator
 
 ##### Defined in
 
-[index.ts:31](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L31)
+[index.ts:31](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L31)
 
 ___
 
@@ -690,4 +688,4 @@ Condition value
 
 ##### Defined in
 
-[index.ts:35](https://github.com/nlxai/sdk/blob/8b2565ceff73829eab8f953f60dbcbd834e25439/packages/journey-manager/src/index.ts#L35)
+[index.ts:35](https://github.com/nlxai/sdk/blob/780ef075aad846baf30d1d35cba0dfe1e91281ff/packages/journey-manager/src/index.ts#L35)


### PR DESCRIPTION
Fixes https://linear.app/nlxai/issue/FRO-17/pulsing-highlights-on-journey-manager.

@jakub-nlx this removes `findActiveTriggers` from the public API as it becomes internal to the package. So we can improve on the implementation later without having the end user have to change anything. Lame 500ms setInterval-based implementation for now, but only triggers if highlights are enabled.

https://github.com/nlxai/sdk/assets/6738398/d40a1677-ba1c-47cb-933f-88b256eb13e5

