### PR TITLE
Send intentId to NLU

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20026,6 +20026,7 @@
         "@nlxai/chat-core": "*",
         "@nlxai/chat-react": "*",
         "@nlxai/chat-widget": "*",
+        "@nlxai/journey-manager": "*",
         "@nlxai/multimodal": "*",
         "@react-hookz/web": "^23.1.0",
         "fuse.js": "^7.0.0",

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -134,6 +134,17 @@ export interface BotResponseMetadata {
 }
 
 /**
+ * Metadata for the individual bot message
+ * as well as whether the client should poll for more bot responses.
+ */
+export interface BotMessageMetadata {
+  /**
+   * The message node's intent
+   */
+  intentId?: string;
+}
+
+/**
  * A message from the bot, as well as any choices the user can make.
  */
 export interface BotMessage {
@@ -154,6 +165,10 @@ export interface BotMessage {
    * A selection of choices to show to the user. They may choose one of them.
    */
   choices: Choice[];
+  /**
+   * Metadata
+   */
+  metadata?: BotMessageMetadata;
   /**
    * After a choice has been made by the user, this will be updated locally to the selected choice id.
    * This field is set locally and does not come from the bot.
@@ -426,6 +441,10 @@ export interface ChoiceRequestMetadata {
    * The `nodeId` can be found in the corresponding {@link BotMessage}.
    */
   nodeId?: string;
+  /**
+   * Intent ID, used for sending to the NLU to allow it to double-check
+   */
+  intentId?: string;
 }
 
 /**
@@ -892,6 +911,7 @@ export default function createConversation(
         request: {
           structured: {
             nodeId: metadata?.nodeId,
+            intentId: metadata?.intentId,
             choiceId,
           },
         },

--- a/packages/chat-widget/src/index.tsx
+++ b/packages/chat-widget/src/index.tsx
@@ -201,6 +201,8 @@ const MessageGroups: FC<{
                                     allowChoiceReselection
                                       ? {
                                           nodeId: botMessage.nodeId,
+                                          intentId:
+                                            botMessage.metadata?.intentId,
                                           responseIndex,
                                           messageIndex: botMessageIndex,
                                         }
@@ -519,7 +521,7 @@ export const Widget = forwardRef<WidgetRef, Props>(function Widget(props, ref) {
   const scrollToBottom = useCallback(() => {
     const node = messagesContainerRef.current;
     if (node != null) {
-      node.scroll({top: node.scrollHeight, behavior: 'smooth'});
+      node.scroll({ top: node.scrollHeight, behavior: "smooth" });
     }
   }, [messagesContainerRef]);
 

--- a/packages/website/src/content/04-03-react-api-reference.md
+++ b/packages/website/src/content/04-03-react-api-reference.md
@@ -36,7 +36,7 @@ the hook object containing the chat state and methods.
 
 #### Defined in
 
-[index.ts:52](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-react/src/index.ts#L52)
+[index.ts:52](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-react/src/index.ts#L52)
 
 
 <a name="indexmd"></a>
@@ -63,7 +63,7 @@ handled by the hook automatically.
 
 ##### Defined in
 
-[index.ts:21](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-react/src/index.ts#L21)
+[index.ts:21](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-react/src/index.ts#L21)
 
 ___
 
@@ -77,7 +77,7 @@ Using this field is optional and you can hold input state separately.
 
 ##### Defined in
 
-[index.ts:27](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-react/src/index.ts#L27)
+[index.ts:27](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-react/src/index.ts#L27)
 
 ___
 
@@ -103,7 +103,7 @@ Modify the value of the chat input field.
 
 ##### Defined in
 
-[index.ts:32](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-react/src/index.ts#L32)
+[index.ts:32](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-react/src/index.ts#L32)
 
 ___
 
@@ -117,7 +117,7 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 ##### Defined in
 
-[index.ts:38](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-react/src/index.ts#L38)
+[index.ts:38](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-react/src/index.ts#L38)
 
 ___
 
@@ -130,4 +130,4 @@ bubble with loading dots.
 
 ##### Defined in
 
-[index.ts:43](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-react/src/index.ts#L43)
+[index.ts:43](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-react/src/index.ts#L43)

--- a/packages/website/src/content/04-04-preact-api-reference.md
+++ b/packages/website/src/content/04-04-preact-api-reference.md
@@ -36,7 +36,7 @@ the hook object containing the chat state and methods.
 
 #### Defined in
 
-[index.ts:52](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-preact/src/index.ts#L52)
+[index.ts:52](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-preact/src/index.ts#L52)
 
 
 <a name="indexmd"></a>
@@ -63,7 +63,7 @@ handled by the hook automatically.
 
 ##### Defined in
 
-[index.ts:21](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-preact/src/index.ts#L21)
+[index.ts:21](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-preact/src/index.ts#L21)
 
 ___
 
@@ -77,7 +77,7 @@ Using this field is optional and you can hold input state separately.
 
 ##### Defined in
 
-[index.ts:27](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-preact/src/index.ts#L27)
+[index.ts:27](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-preact/src/index.ts#L27)
 
 ___
 
@@ -103,7 +103,7 @@ Modify the value of the chat input field.
 
 ##### Defined in
 
-[index.ts:32](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-preact/src/index.ts#L32)
+[index.ts:32](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-preact/src/index.ts#L32)
 
 ___
 
@@ -117,7 +117,7 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 ##### Defined in
 
-[index.ts:38](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-preact/src/index.ts#L38)
+[index.ts:38](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-preact/src/index.ts#L38)
 
 ___
 
@@ -130,4 +130,4 @@ bubble with loading dots.
 
 ##### Defined in
 
-[index.ts:43](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-preact/src/index.ts#L43)
+[index.ts:43](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-preact/src/index.ts#L43)

--- a/packages/website/src/content/05-02-headless-api-reference.md
+++ b/packages/website/src/content/05-02-headless-api-reference.md
@@ -1,242 +1,148 @@
 
 <a name="readmemd"></a>
 
-# @nlxai/chat-core
+# @nlxai/chat-widget
 
 ## Interfaces
 
-- [SlotValue](#interfacesslotvaluemd)
-- [BotResponse](#interfacesbotresponsemd)
-- [BotResponsePayload](#interfacesbotresponsepayloadmd)
-- [BotResponseMetadata](#interfacesbotresponsemetadatamd)
-- [BotMessage](#interfacesbotmessagemd)
-- [Choice](#interfaceschoicemd)
-- [UserResponse](#interfacesuserresponsemd)
-- [FailureMessage](#interfacesfailuremessagemd)
-- [Config](#interfacesconfigmd)
-- [StructuredRequest](#interfacesstructuredrequestmd)
-- [ChoiceRequestMetadata](#interfaceschoicerequestmetadatamd)
-- [ConversationHandler](#interfacesconversationhandlermd)
+- [WidgetInstance](#interfaceswidgetinstancemd)
+- [WidgetRef](#interfaceswidgetrefmd)
+- [TitleBar](#interfacestitlebarmd)
+- [Nudge](#interfacesnudgemd)
+- [Props](#interfacespropsmd)
+- [Theme](#interfacesthememd)
 
 ## Type Aliases
 
-### Context
+### StorageType
 
-Ƭ **Context**: `Record`\<`string`, `any`\>
+Ƭ **StorageType**: ``"localStorage"`` \| ``"sessionStorage"``
 
-[Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent.
+When this option is set to `"localStorage"` or `"sessionStorage"`,
+the state of the chat conversation is persisted in [local](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+or [session](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) storage respectively.
 
-#### Defined in
+This allows the state and history of the conversation to persist between
+full page refreshes.
 
-[index.ts:13](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L13)
-
-___
-
-### SlotsRecord
-
-Ƭ **SlotsRecord**: `Record`\<`string`, `any`\>
-
-Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
-
-`SlotRecord` Keys are the attached slot's name
-
-`SlotRecord` Values are usually a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
-for custom slots, this can optionally be the value's ID.
-
-A `SlotsRecord` is equivalent to an array of [SlotValue](#interfacesslotvaluemd) objects.
+\> When using the session storage feature, it is your responsibility
+\> to make sure that your website complies with your data protection
+\> and privacy policy requirements.
 
 #### Defined in
 
-[index.ts:42](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L42)
+[packages/chat-widget/src/props.ts:45](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L45)
 
 ___
 
-### SlotsRecordOrArray
+### CustomModalityComponent
 
-Ƭ **SlotsRecordOrArray**: [`SlotsRecord`](#slotsrecord) \| [`SlotValue`](#interfacesslotvaluemd)[]
+Ƭ **CustomModalityComponent**: `FC`\<\{ `key`: `string` ; `data`: `any`  }\>
 
-Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
-
-Supports either a [SlotsRecord](#slotsrecord) or an array of [SlotValue](#interfacesslotvaluemd) objects
+Custom Modalities allow rendering of rich components from nodes.
+See: https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode/advanced-messaging-+-functionality#modalities
 
 #### Defined in
 
-[index.ts:49](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L49)
+[packages/chat-widget/src/props.ts:51](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L51)
 
-___
+## Variables
 
-### UserResponsePayload
+### defaultTheme
 
-Ƭ **UserResponsePayload**: \{ `type`: ``"text"`` ; `text`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"choice"`` ; `choiceId`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"structured"`` ; `context?`: [`Context`](#context)  } & [`StructuredRequest`](#interfacesstructuredrequestmd)
+• `Const` **defaultTheme**: [`Theme`](#interfacesthememd)
 
-The payload of the user response
-
-#### Defined in
-
-[index.ts:209](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L209)
-
-___
-
-### Response
-
-Ƭ **Response**: [`BotResponse`](#interfacesbotresponsemd) \| [`UserResponse`](#interfacesuserresponsemd) \| [`FailureMessage`](#interfacesfailuremessagemd)
-
-A response from the bot or the user.
+the default theme
 
 #### Defined in
 
-[index.ts:278](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L278)
+[packages/chat-widget/src/ui/constants.ts:16](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/ui/constants.ts#L16)
 
-___
+## Functions
 
-### Time
+### create
 
-Ƭ **Time**: `number`
+▸ **create**(`props`): [`WidgetInstance`](#interfaceswidgetinstancemd)
 
-The time value in milliseconds since midnight, January 1, 1970 UTC.
+Create a new chat widget and renders it as the last element in the body.
 
-#### Defined in
-
-[index.ts:283](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L283)
-
-___
-
-### Subscriber
-
-Ƭ **Subscriber**: (`response`: [`Response`](#response)[], `newResponse?`: [`Response`](#response)) => `void`
-
-The callback function for listening to all responses.
-
-#### Type declaration
-
-▸ (`response`, `newResponse?`): `void`
-
-##### Parameters
+#### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `response` | [`Response`](#response)[] |
-| `newResponse?` | [`Response`](#response) |
+| `props` | [`Props`](#interfacespropsmd) |
 
-##### Returns
+#### Returns
+
+[`WidgetInstance`](#interfaceswidgetinstancemd)
+
+the WidgetInstance to script widget behavior.
+
+#### Defined in
+
+[packages/chat-widget/src/index.tsx:102](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L102)
+
+___
+
+### clearSession
+
+▸ **clearSession**(`storeIn`): `void`
+
+Clears stored session history.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `storeIn` | [`StorageType`](#storagetype) | where to clear the session. |
+
+#### Returns
 
 `void`
 
 #### Defined in
 
-[index.ts:533](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L533)
-
-## Functions
-
-### shouldReinitialize
-
-▸ **shouldReinitialize**(`config1`, `config2`): `boolean`
-
-Helper method to decide when a new [Config](#interfacesconfigmd) requires creating a new [ConversationHandler](#interfacesconversationhandlermd) or whether the old `Config`'s
-`ConversationHandler` can be used.
-
-The order of configs doesn't matter.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `config1` | [`Config`](#interfacesconfigmd) |
-| `config2` | [`Config`](#interfacesconfigmd) |
-
-#### Returns
-
-`boolean`
-
-true if `createConversation` should be called again
-
-#### Defined in
-
-[index.ts:544](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L544)
+[packages/chat-widget/src/index.tsx:302](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L302)
 
 ___
 
-### default
+### useConversationHandler
 
-▸ **default**(`config`): [`ConversationHandler`](#interfacesconversationhandlermd)
+▸ **useConversationHandler**(): ``null`` \| `ConversationHandler`
 
-Call this to create a conversation handler.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `config` | [`Config`](#interfacesconfigmd) |
+Hook to get the ConversationHandler for the widget.
+This may be called before the Widget has been created.
+It will return null until the Widget has been created and the conversation has been established.
 
 #### Returns
 
-[`ConversationHandler`](#interfacesconversationhandlermd)
+``null`` \| `ConversationHandler`
 
-The [ConversationHandler](#interfacesconversationhandlermd) is a bundle of functions to interact with the conversation.
+the ConversationHandler if the widget has been created and its conversation has been established, otherwise it returns null.
 
 #### Defined in
 
-[index.ts:556](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L556)
+[packages/chat-widget/src/index.tsx:370](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L370)
 
 ___
 
-### promisify
+### Widget
 
-▸ **promisify**\<`T`\>(`fn`, `convo`, `timeout?`): (`payload`: `T`) => `Promise`\<[`Response`](#response) \| ``null``\>
-
-This package is intentionally designed with a subscription-based API as opposed to a promise-based one where each message corresponds to a single bot response, available asynchronously.
-
-If you need a promise-based wrapper, you can use the `promisify` helper available in the package:
-
-#### Type parameters
-
-| Name | Description |
-| :------ | :------ |
-| `T` | the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context` |
+▸ **Widget**(`props`): `ReactNode`
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `fn` | (`payload`: `T`) => `void` | `undefined` | the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.) |
-| `convo` | [`ConversationHandler`](#interfacesconversationhandlermd) | `undefined` | the `ConversationHandler` (from [createConversation](#default)) |
-| `timeout` | `number` | `10000` | the timeout in milliseconds |
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Props`](#interfacespropsmd) & `RefAttributes`\<[`WidgetRef`](#interfaceswidgetrefmd)\> |
 
 #### Returns
 
-`fn`
-
-A promise-wrapped version of the function. The function, when called, returns a promise that resolves to the Conversation's next response.
-
-▸ (`payload`): `Promise`\<[`Response`](#response) \| ``null``\>
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `payload` | `T` |
-
-##### Returns
-
-`Promise`\<[`Response`](#response) \| ``null``\>
-
-**`Example`**
-
-```typescript
-import { createConversation, promisify } from "@nlxai/chat-core";
-
-const convo = createConversation(config);
-
-const sendTextWrapped = promisify(convo.sendText, convo);
-
-sendTextWrapped("Hello").then((response) => {
-  console.log(response);
-});
-```
+`ReactNode`
 
 #### Defined in
 
-[index.ts:949](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L949)
+[packages/chat-widget/src/index.tsx:374](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L374)
 
 
 <a name="indexmd"></a>
@@ -245,509 +151,198 @@ sendTextWrapped("Hello").then((response) => {
 # Interfaces
 
 
-<a name="interfacesbotmessagemd"></a>
+<a name="interfacesnudgemd"></a>
 
-## Interface: BotMessage
+## Interface: Nudge
 
-A message from the bot, as well as any choices the user can make.
+When set, a dismissable call-to-action will appear above the chat icon with the given text.
 
-### Properties
+By default, the call-to-action will be displayed after 3 seconds, and will automatically dismiss after 20 seconds.
 
-#### messageId
-
-• `Optional` **messageId**: `string`
-
-A unique identifier for the message.
-
-##### Defined in
-
-[index.ts:143](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L143)
-
-___
-
-#### nodeId
-
-• `Optional` **nodeId**: `string`
-
-The node id that this message is associated with.
-This is must be sent with a choice when the user is changing a previously sent choice.
-
-##### Defined in
-
-[index.ts:148](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L148)
-
-___
-
-#### text
-
-• **text**: `string`
-
-The body of the message. Show this to the user.
-
-##### Defined in
-
-[index.ts:152](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L152)
-
-___
-
-#### choices
-
-• **choices**: [`Choice`](#interfaceschoicemd)[]
-
-A selection of choices to show to the user. They may choose one of them.
-
-##### Defined in
-
-[index.ts:156](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L156)
-
-___
-
-#### selectedChoiceId
-
-• `Optional` **selectedChoiceId**: `string`
-
-After a choice has been made by the user, this will be updated locally to the selected choice id.
-This field is set locally and does not come from the bot.
-
-##### Defined in
-
-[index.ts:161](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L161)
-
-
-<a name="interfacesbotresponsemd"></a>
-
-## Interface: BotResponse
-
-A message from the bot
-
-See also:
-- [UserResponse](#interfacesuserresponsemd)
-- [FailureMessage](#interfacesfailuremessagemd)
-- [Response](#response)
+It will be dissapear when the chat is opened, but until dismissed, will reappear whenever the chat is minimized or closed.
 
 ### Properties
 
-#### type
+#### content
 
-• **type**: ``"bot"``
+• **content**: `string`
 
-The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
+The text content of the nudge. Markdown is supported.
 
 ##### Defined in
 
-[index.ts:63](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L63)
+[packages/chat-widget/src/props.ts:73](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L73)
 
 ___
 
-#### receivedAt
+#### showAfter
 
-• **receivedAt**: `number`
+• `Optional` **showAfter**: `number`
 
-When the response was received
+Show the nudge after a specific time, measured in milliseconds.
+Defaults to 3000 (3s) if not set.
 
 ##### Defined in
 
-[index.ts:67](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L67)
+[packages/chat-widget/src/props.ts:78](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L78)
 
 ___
 
-#### payload
+#### hideAfter
 
-• **payload**: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)
+• `Optional` **hideAfter**: `number`
 
-The payload of the response
+Hide the nudge after a specific time after it appears, measured in milliseconds.
+Defaults to 20000 (20s) if not set.
 
 ##### Defined in
 
-[index.ts:71](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L71)
+[packages/chat-widget/src/props.ts:83](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L83)
 
 
-<a name="interfacesbotresponsemetadatamd"></a>
+<a name="interfacespropsmd"></a>
 
-## Interface: BotResponseMetadata
+## Interface: Props
 
-Global state about the current conversation
-as well as whether the client should poll for more bot responses.
+The properties for creating the Chat Widget.
 
 ### Properties
 
-#### intentId
+#### config
 
-• `Optional` **intentId**: `string`
-
-The conversation's intent
-
-##### Defined in
-
-[index.ts:117](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L117)
-
-___
-
-#### escalation
-
-• `Optional` **escalation**: `boolean`
-
-Whether the current conversation has been marked as incomprehension.
-
-##### Defined in
-
-[index.ts:121](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L121)
-
-___
-
-#### frustration
-
-• `Optional` **frustration**: `boolean`
-
-Whether the current conversation has been marked frustrated
-
-##### Defined in
-
-[index.ts:125](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L125)
-
-___
-
-#### incomprehension
-
-• `Optional` **incomprehension**: `boolean`
-
-Whether the current conversation has been marked as incomprehension.
-
-##### Defined in
-
-[index.ts:129](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L129)
-
-___
-
-#### hasPendingDataRequest
-
-• `Optional` **hasPendingDataRequest**: `boolean`
-
-Whether the client should poll for more bot responses.
-
-##### Defined in
-
-[index.ts:133](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L133)
-
-
-<a name="interfacesbotresponsepayloadmd"></a>
-
-## Interface: BotResponsePayload
-
-The payload of the bot response
-
-### Properties
-
-#### expirationTimestamp
-
-• `Optional` **expirationTimestamp**: `number`
-
-If there isn't some interaction by this time, the conversation will expire.
-
-##### Defined in
-
-[index.ts:81](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L81)
-
-___
-
-#### conversationId
-
-• `Optional` **conversationId**: `string`
-
-The active conversation ID. If not set, a new conversation will be started.
-
-##### Defined in
-
-[index.ts:85](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L85)
-
-___
-
-#### messages
-
-• **messages**: [`BotMessage`](#interfacesbotmessagemd)[]
-
-Any messages from the bot.
-
-##### Defined in
-
-[index.ts:89](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L89)
-
-___
-
-#### metadata
-
-• `Optional` **metadata**: [`BotResponseMetadata`](#interfacesbotresponsemetadatamd)
-
-Global state about the current conversation
-as well as whether the client should poll for more bot responses.
-
-##### Defined in
-
-[index.ts:94](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L94)
-
-___
-
-#### payload
-
-• `Optional` **payload**: `string`
-
-If configured, the [node's payload.](#add-functionality)
-
-##### Defined in
-
-[index.ts:98](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L98)
-
-___
-
-#### modalities
-
-• `Optional` **modalities**: `Record`\<`string`, `any`\>
-
-If configured, the node's modalities and their payloads.
-
-##### Defined in
-
-[index.ts:102](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L102)
-
-___
-
-#### context
-
-• `Optional` **context**: [`Context`](#context)
-
-If the node is set to send context, the whole context associated with the conversation.
-
-##### Defined in
-
-[index.ts:106](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L106)
-
-
-<a name="interfaceschoicemd"></a>
-
-## Interface: Choice
-
-A choices to show to the user.
-
-### Properties
-
-#### choiceId
-
-• **choiceId**: `string`
-
-`choiceId` is used by `sendChoice` to let the user choose this choice.
-
-##### Defined in
-
-[index.ts:171](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L171)
-
-___
-
-#### choiceText
-
-• **choiceText**: `string`
-
-The text of the choice
-
-##### Defined in
-
-[index.ts:175](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L175)
-
-___
-
-#### choicePayload
-
-• `Optional` **choicePayload**: `any`
-
-An optional, schemaless payload for the choice.
-
-##### Defined in
-
-[index.ts:179](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L179)
-
-
-<a name="interfaceschoicerequestmetadatamd"></a>
-
-## Interface: ChoiceRequestMetadata
-
-Helps link the choice to the specific message in the conversation.
-
-### Properties
-
-#### responseIndex
-
-• `Optional` **responseIndex**: `number`
-
-The index of the [Response](#response) associated with this choice.
-Setting this ensures that local state's `selectedChoiceId` on the corresponding [BotResponse](#interfacesbotresponsemd) is set.
-It is not sent to the bot.
-
-##### Defined in
-
-[index.ts:417](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L417)
-
-___
-
-#### messageIndex
-
-• `Optional` **messageIndex**: `number`
-
-The index of the [BotMessage](#interfacesbotmessagemd) associated with this choice.
-Setting this ensures that local state's `selectedChoiceId` on the corresponding [BotResponse](#interfacesbotresponsemd) is set.
-It is not sent to the bot.
-
-##### Defined in
-
-[index.ts:423](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L423)
-
-___
-
-#### nodeId
-
-• `Optional` **nodeId**: `string`
-
-Required if you want to change a choice that's already been sent.
-The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessagemd).
-
-##### Defined in
-
-[index.ts:428](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L428)
-
-
-<a name="interfacesconfigmd"></a>
-
-## Interface: Config
+• **config**: `Config`
 
 The configuration to create a conversation.
 
-### Properties
-
-#### botUrl
-
-• **botUrl**: `string`
-
-Fetch this from the bot's Deployment page.
-
 ##### Defined in
 
-[index.ts:299](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L299)
+[packages/chat-widget/src/props.ts:93](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L93)
 
 ___
 
-#### headers
+#### theme
 
-• **headers**: `Record`\<`string`, `string`\> & \{ `nlx-api-key`: `string`  }
+• `Optional` **theme**: `Partial`\<[`Theme`](#interfacesthememd)\>
 
-Headers to forward to the NLX API.
-
-##### Defined in
-
-[index.ts:303](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L303)
-
-___
-
-#### conversationId
-
-• `Optional` **conversationId**: `string`
-
-Set `conversationId` to continue an existing conversation. If not set, a new conversation will be started.
+The theme to apply to the chat widget.
 
 ##### Defined in
 
-[index.ts:313](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L313)
+[packages/chat-widget/src/props.ts:97](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L97)
 
 ___
 
-#### userId
+#### titleBar
 
-• `Optional` **userId**: `string`
+• `Optional` **titleBar**: [`TitleBar`](#interfacestitlebarmd)
 
-Setting the `userID` allows it to be searchable in bot history, as well as usable via `{System.userId}` in the intent.
+How to configure the title bar. When missing, the widget will not have a title bar.
 
 ##### Defined in
 
-[index.ts:317](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L317)
+[packages/chat-widget/src/props.ts:101](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L101)
 
 ___
 
-#### responses
+#### chatIcon
 
-• `Optional` **responses**: [`Response`](#response)[]
+• `Optional` **chatIcon**: `string`
 
-When `responses` is set, initialize the chatHandler with historical messages.
+If you want a custom chat icon, set this to the URL of an image to use.
 
 ##### Defined in
 
-[index.ts:321](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L321)
+[packages/chat-widget/src/props.ts:105](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L105)
 
 ___
 
-#### failureMessage
+#### nudge
 
-• `Optional` **failureMessage**: `string`
+• `Optional` **nudge**: [`Nudge`](#interfacesnudgemd)
 
-When set, this overrides the default failure message ("We encountered an issue. Please try again soon.").
+An optional [Nudge](#interfacesnudgemd) configuration object.
 
 ##### Defined in
 
-[index.ts:325](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L325)
+[packages/chat-widget/src/props.ts:109](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L109)
 
 ___
 
-#### languageCode
+#### inputPlaceholder
 
-• **languageCode**: `string`
+• `Optional` **inputPlaceholder**: `string`
 
-The language code to use for the bot. In the browser this can be fetched with `navigator.language`.
-If you don't have translations, hard-code this to the language code you support.
+The placeholder in the input field. When not set, the default placeholder is "Type something..."
 
 ##### Defined in
 
-[index.ts:330](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L330)
+[packages/chat-widget/src/props.ts:113](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L113)
 
 ___
 
-#### experimental
+#### loaderMessage
 
-• `Optional` **experimental**: `Object`
+• `Optional` **loaderMessage**: `string`
 
-Experimental settings
+A message to display to the user while the bot is still processing the previous message from the user.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:117](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L117)
+
+___
+
+#### showLoaderMessageAfter
+
+• `Optional` **showLoaderMessageAfter**: `number`
+
+How long to wait, in milliseconds, before the loader message is displayed. Default is 2,500ms.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:121](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L121)
+
+___
+
+#### allowChoiceReselection
+
+• `Optional` **allowChoiceReselection**: `boolean`
+
+If set to true, previously selected choices in the chat can be changed.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:125](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L125)
+
+___
+
+#### storeIn
+
+• `Optional` **storeIn**: [`StorageType`](#storagetype)
+
+When set, chat history & conversation will be stored in the browser.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:129](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L129)
+
+___
+
+#### onExpand
+
+• `Optional` **onExpand**: (`conversationHandler`: `ConversationHandler`) => `void`
+
+Optional callback to be called when the chat is expanded.
 
 ##### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `channelType?` | `string` | Simulate alternative channel types |
-| `completeBotUrl?` | `boolean` | Prevent the `languageCode` parameter to be appended to the bot URL - used in special deployment environments such as the sandbox chat inside Dialog Studio |
-
-##### Defined in
-
-[index.ts:339](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L339)
-
-
-<a name="interfacesconversationhandlermd"></a>
-
-## Interface: ConversationHandler
-
-A bundle of functions to interact with a conversation, created by [createConversation](#default).
-
-### Properties
-
-#### sendText
-
-• **sendText**: (`text`: `string`, `context?`: [`Context`](#context)) => `void`
-
-Send user's message
-
-##### Type declaration
-
-▸ (`text`, `context?`): `void`
+▸ (`conversationHandler`): `void`
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `text` | `string` | the user's message |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| Name | Type |
+| :------ | :------ |
+| `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
 
@@ -755,26 +350,25 @@ Send user's message
 
 ##### Defined in
 
-[index.ts:440](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L440)
+[packages/chat-widget/src/props.ts:133](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L133)
 
 ___
 
-#### sendSlots
+#### onCollapse
 
-• **sendSlots**: (`slots`: [`SlotsRecordOrArray`](#slotsrecordorarray), `context?`: [`Context`](#context)) => `void`
+• `Optional` **onCollapse**: (`conversationHandler`: `ConversationHandler`) => `void`
 
-Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settings) to the bot.
+Optional callback to be called when the chat is collapsed. This is also called when the chat is closed.
 
 ##### Type declaration
 
-▸ (`slots`, `context?`): `void`
+▸ (`conversationHandler`): `void`
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `slots` | [`SlotsRecordOrArray`](#slotsrecordorarray) | The slots to populate |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| Name | Type |
+| :------ | :------ |
+| `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
 
@@ -782,181 +376,15 @@ Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settin
 
 ##### Defined in
 
-[index.ts:446](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L446)
+[packages/chat-widget/src/props.ts:137](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L137)
 
 ___
 
-#### sendChoice
+#### onClose
 
-• **sendChoice**: (`choiceId`: `string`, `context?`: [`Context`](#context), `metadata?`: [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd)) => `void`
+• `Optional` **onClose**: () => `void`
 
-Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode/nodes#user-choice) from the bot.
-
-##### Type declaration
-
-▸ (`choiceId`, `context?`, `metadata?`): `void`
-
-###### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `choiceId` | `string` | - |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
-| `metadata?` | [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd) | links the choice to the specific message and node in the conversation. |
-
-###### Returns
-
-`void`
-
-##### Defined in
-
-[index.ts:453](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L453)
-
-___
-
-#### sendWelcomeIntent
-
-• **sendWelcomeIntent**: (`context?`: [`Context`](#context)) => `void`
-
-Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents). This should be done when the user starts interacting with the chat.
-
-##### Type declaration
-
-▸ (`context?`): `void`
-
-###### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
-
-###### Returns
-
-`void`
-
-##### Defined in
-
-[index.ts:463](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L463)
-
-___
-
-#### sendIntent
-
-• **sendIntent**: (`intentId`: `string`, `context?`: [`Context`](#context)) => `void`
-
-Trigger a specific [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents).
-
-##### Type declaration
-
-▸ (`intentId`, `context?`): `void`
-
-###### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `intentId` | `string` | the intent to trigger. The id is the name under the Bot's _Intents_. |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
-
-###### Returns
-
-`void`
-
-##### Defined in
-
-[index.ts:470](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L470)
-
-___
-
-#### sendStructured
-
-• **sendStructured**: (`request`: [`StructuredRequest`](#interfacesstructuredrequestmd), `context?`: [`Context`](#context)) => `void`
-
-Send a combination of choice, slots, and intent in one request.
-
-##### Type declaration
-
-▸ (`request`, `context?`): `void`
-
-###### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `request` | [`StructuredRequest`](#interfacesstructuredrequestmd) |  |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
-
-###### Returns
-
-`void`
-
-##### Defined in
-
-[index.ts:477](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L477)
-
-___
-
-#### subscribe
-
-• **subscribe**: (`subscriber`: [`Subscriber`](#subscriber)) => () => `void`
-
-Subscribe a callback to the conversation. On subscribe, the subscriber will receive all of the Responses that the conversation has already received.
-
-##### Type declaration
-
-▸ (`subscriber`): () => `void`
-
-###### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `subscriber` | [`Subscriber`](#subscriber) | The callback to subscribe |
-
-###### Returns
-
-`fn`
-
-▸ (): `void`
-
-###### Returns
-
-`void`
-
-##### Defined in
-
-[index.ts:482](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L482)
-
-___
-
-#### unsubscribe
-
-• **unsubscribe**: (`subscriber`: [`Subscriber`](#subscriber)) => `void`
-
-Unsubscribe a callback from the conversation.
-
-##### Type declaration
-
-▸ (`subscriber`): `void`
-
-###### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `subscriber` | [`Subscriber`](#subscriber) | The callback to unsubscribe |
-
-###### Returns
-
-`void`
-
-##### Defined in
-
-[index.ts:487](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L487)
-
-___
-
-#### unsubscribeAll
-
-• **unsubscribeAll**: () => `void`
-
-Unsubscribe all callback from the conversation.
+Optional callback to be called when the chat is closed via the close button.
 
 ##### Type declaration
 
@@ -968,47 +396,25 @@ Unsubscribe all callback from the conversation.
 
 ##### Defined in
 
-[index.ts:491](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L491)
+[packages/chat-widget/src/props.ts:141](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L141)
 
 ___
 
-#### currentConversationId
+#### onNudgeClose
 
-• **currentConversationId**: () => `undefined` \| `string`
+• `Optional` **onNudgeClose**: (`conversationHandler`: `ConversationHandler`) => `void`
 
-Get the current conversation ID if it's set, or undefined if there is no conversation.
-
-##### Type declaration
-
-▸ (): `undefined` \| `string`
-
-###### Returns
-
-`undefined` \| `string`
-
-##### Defined in
-
-[index.ts:495](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L495)
-
-___
-
-#### reset
-
-• **reset**: (`options?`: \{ `clearResponses?`: `boolean`  }) => `void`
-
-Forces a new conversation. If `clearResponses` is set to true, will also clear historical responses passed to subscribers.
-Retains all existing subscribers.
+Optional callback to be called when the nudge element is closed explicitly by the user. It is not called when the nudge is hidden automatically after the `hideAfter` interval passes.
 
 ##### Type declaration
 
-▸ (`options?`): `void`
+▸ (`conversationHandler`): `void`
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `options?` | `Object` | - |
-| `options.clearResponses?` | `boolean` | If set to true, will clear historical responses passed to subscribers. |
+| Name | Type |
+| :------ | :------ |
+| `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
 
@@ -1016,15 +422,201 @@ Retains all existing subscribers.
 
 ##### Defined in
 
-[index.ts:500](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L500)
+[packages/chat-widget/src/props.ts:145](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L145)
 
 ___
 
-#### destroy
+#### customModalities
 
-• **destroy**: () => `void`
+• `Optional` **customModalities**: `Record`\<`string`, [`CustomModalityComponent`](#custommodalitycomponent)\>
 
-Removes all subscribers and, if using websockets, closes the connection.
+Set this to render a [CustomModalityComponent](#custommodalitycomponent) for a given modality name
+See: https://docs.studio.nlx.ai/intentflows/documentation-flows/flows-build-mode/advanced-messaging-+-functionality#modalities
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:151](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L151)
+
+
+<a name="interfacesthememd"></a>
+
+## Interface: Theme
+
+The theme to apply to the chat widget.
+ Colors may be in any CSS-compatible format like rgb(50, 50, 50) or #aaa
+
+### Properties
+
+#### primaryColor
+
+• **primaryColor**: `string`
+
+Primary color for interactive UI elements like buttons
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:7](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L7)
+
+___
+
+#### darkMessageColor
+
+• **darkMessageColor**: `string`
+
+Background color for the dark chat bubbles (sent by the user)
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:9](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L9)
+
+___
+
+#### lightMessageColor
+
+• **lightMessageColor**: `string`
+
+Background color for the light chat bubbles (sent by the bot)
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:11](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L11)
+
+___
+
+#### white
+
+• **white**: `string`
+
+Customized shade of white
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:13](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L13)
+
+___
+
+#### fontFamily
+
+• **fontFamily**: `string`
+
+Widget font family
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:15](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L15)
+
+___
+
+#### spacing
+
+• **spacing**: `number`
+
+Main spacing unit
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:17](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L17)
+
+___
+
+#### borderRadius
+
+• **borderRadius**: `number`
+
+Chat border radius
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:19](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L19)
+
+___
+
+#### chatWindowMaxHeight
+
+• **chatWindowMaxHeight**: `number`
+
+Max height of the chat window
+
+##### Defined in
+
+[packages/chat-widget/src/theme.ts:21](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/theme.ts#L21)
+
+
+<a name="interfacestitlebarmd"></a>
+
+## Interface: TitleBar
+
+Configures the Title Bar of the Chat Widget.
+This is visible at the top of the widget when it is open / expanded.
+
+### Properties
+
+#### logo
+
+• `Optional` **logo**: `string`
+
+Optional URL to a logo image to be displayed on to the left of the title.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:13](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L13)
+
+___
+
+#### title
+
+• **title**: `string`
+
+The title string.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:17](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L17)
+
+___
+
+#### withCollapseButton
+
+• `Optional` **withCollapseButton**: `boolean`
+
+Setting this to true shows the collapse button ("_").
+Pressing the collapse button will hide the chat overlay but keep it active.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:22](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L22)
+
+___
+
+#### withCloseButton
+
+• `Optional` **withCloseButton**: `boolean`
+
+Setting this to true shows the close button ("X").
+Pressing the close button will
+- hide the chat overlay
+- terminate the ongoing conversation
+- call the chat's onClose handler if provided.
+
+##### Defined in
+
+[packages/chat-widget/src/props.ts:30](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/props.ts#L30)
+
+
+<a name="interfaceswidgetinstancemd"></a>
+
+## Interface: WidgetInstance
+
+A handler for a Widget. Created with [create](#create)
+
+### Properties
+
+#### teardown
+
+• **teardown**: () => `void`
+
+End the conversation, clean up all event handlers, and remove the widget from the DOM.
+If you want to additionally clear a stored session, explicitly call [clearSession](#clearsession) with your [Props](#interfacespropsmd).
 
 ##### Type declaration
 
@@ -1036,192 +628,125 @@ Removes all subscribers and, if using websockets, closes the connection.
 
 ##### Defined in
 
-[index.ts:509](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L509)
-
-
-<a name="interfacesfailuremessagemd"></a>
-
-## Interface: FailureMessage
-
-A failure message is received when the NLX api is unreachable, or sends an unparsable response.
-
-### Properties
-
-#### type
-
-• **type**: ``"failure"``
-
-The type of the response is `"bot"` for bot and `"user"` for user.
-
-##### Defined in
-
-[index.ts:259](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L259)
+[packages/chat-widget/src/index.tsx:62](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L62)
 
 ___
 
-#### payload
+#### expand
 
-• **payload**: `Object`
+• **expand**: () => `void`
 
-The payload only includes an error message.
+Expand the widget and call the `onExpand` callback if present.
 
 ##### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `text` | `string` | The error message is either the default, or the `failureMessage` set in the [Config](#interfacesconfigmd). |
+▸ (): `void`
+
+###### Returns
+
+`void`
 
 ##### Defined in
 
-[index.ts:263](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L263)
+[packages/chat-widget/src/index.tsx:66](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L66)
 
 ___
 
-#### receivedAt
+#### collapse
 
-• **receivedAt**: `number`
+• **collapse**: () => `void`
 
-When the failure occurred.
+Collapse the widget and call the `onCollapse` callback if present.
+
+##### Type declaration
+
+▸ (): `void`
+
+###### Returns
+
+`void`
 
 ##### Defined in
 
-[index.ts:272](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L272)
+[packages/chat-widget/src/index.tsx:70](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L70)
+
+___
+
+#### getConversationHandler
+
+• **getConversationHandler**: () => `undefined` \| `ConversationHandler`
+
+Get the ConversationHandler for widget. Returns undefined if the widget has not yet been established.
+Note that this might not be available synchronously after widget initialization, and therefore an `undefined` check is highly recommended before use.
+See: https://developers.nlx.ai/headless-api-reference#interfacesconversationhandlermd
+
+##### Type declaration
+
+▸ (): `undefined` \| `ConversationHandler`
+
+###### Returns
+
+`undefined` \| `ConversationHandler`
+
+##### Defined in
+
+[packages/chat-widget/src/index.tsx:76](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L76)
 
 
-<a name="interfacesslotvaluemd"></a>
+<a name="interfaceswidgetrefmd"></a>
 
-## Interface: SlotValue
+## Interface: WidgetRef
 
-Values to fill an intent's [attached slots](https://docs.studio.nlx.ai/intents/documentation-intents/intents-attached-slots).
-
-An array of `SlotValue` objects is equivalent to a [SlotsRecord](#slotsrecord).
+Widget Ref, for use when rendering a Widget without using the `create` helper function.
 
 ### Properties
 
-#### slotId
+#### expand
 
-• **slotId**: `string`
+• **expand**: () => `void`
 
-The attached slot's name
+Expand the widget and call the `onExpand` callback if present.
+
+##### Type declaration
+
+▸ (): `void`
+
+###### Returns
+
+`void`
 
 ##### Defined in
 
-[index.ts:24](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L24)
+[packages/chat-widget/src/index.tsx:86](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L86)
 
 ___
 
-#### value
+#### collapse
 
-• **value**: `any`
+• **collapse**: () => `void`
 
-Usually this will be a discrete value matching the slots's [type](https://docs.studio.nlx.ai/slots/documentation-slots/slots-values#system-slots).
-for custom slots, this can optionally be the value's ID.
+Collapse the widget and call the `onCollapse` callback if present.
 
-##### Defined in
+##### Type declaration
 
-[index.ts:29](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L29)
+▸ (): `void`
 
+###### Returns
 
-<a name="interfacesstructuredrequestmd"></a>
-
-## Interface: StructuredRequest
-
-The body of `sendStructured`
-Includes a combination of choice, slots, and intent in one request.
-
-### Properties
-
-#### choiceId
-
-• `Optional` **choiceId**: `string`
-
-The `choiceId` is in the [BotResponse](#interfacesbotresponsemd)'s `.payload.messages[].choices[].choiceId` fields
+`void`
 
 ##### Defined in
 
-[index.ts:375](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L375)
+[packages/chat-widget/src/index.tsx:90](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L90)
 
 ___
 
-#### nodeId
+#### conversationHandler
 
-• `Optional` **nodeId**: `string`
+• **conversationHandler**: `ConversationHandler`
 
-Required if you want to change a choice that's already been sent.
-The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessagemd).
-
-##### Defined in
-
-[index.ts:380](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L380)
-
-___
-
-#### intentId
-
-• `Optional` **intentId**: `string`
-
-The intent to trigger. The `intentId` is the name under the Bot's _Intents_.
+the ConversationHandler for the widget.
 
 ##### Defined in
 
-[index.ts:384](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L384)
-
-___
-
-#### slots
-
-• `Optional` **slots**: [`SlotsRecordOrArray`](#slotsrecordorarray)
-
-The slots to populate
-
-##### Defined in
-
-[index.ts:388](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L388)
-
-
-<a name="interfacesuserresponsemd"></a>
-
-## Interface: UserResponse
-
-A message from the user
-
-See also:
-- [BotResponse](#interfacesbotresponsemd)
-- [FailureMessage](#interfacesfailuremessagemd)
-- [Response](#response)
-
-### Properties
-
-#### type
-
-• **type**: ``"user"``
-
-The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
-
-##### Defined in
-
-[index.ts:195](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L195)
-
-___
-
-#### receivedAt
-
-• **receivedAt**: `number`
-
-When the response was received
-
-##### Defined in
-
-[index.ts:199](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L199)
-
-___
-
-#### payload
-
-• **payload**: [`UserResponsePayload`](#userresponsepayload)
-
-The payload of the response
-
-##### Defined in
-
-[index.ts:203](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/chat-core/src/index.ts#L203)
+[packages/chat-widget/src/index.tsx:94](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/chat-widget/src/index.tsx#L94)

--- a/packages/website/src/content/06-03-multimodal-api-reference.md
+++ b/packages/website/src/content/06-03-multimodal-api-reference.md
@@ -46,7 +46,7 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 #### Defined in
 
-[index.ts:26](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L26)
+[index.ts:26](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L26)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[index.ts:113](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L113)
+[index.ts:113](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L113)
 
 
 <a name="indexmd"></a>
@@ -115,7 +115,7 @@ sends a step to the voice bot
 
 ##### Defined in
 
-[index.ts:106](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L106)
+[index.ts:106](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L106)
 
 
 <a name="interfacesconfigmd"></a>
@@ -134,7 +134,7 @@ Initial configuration used when creating a journey manager
 
 ##### Defined in
 
-[index.ts:121](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L121)
+[index.ts:121](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L121)
 
 ___
 
@@ -146,7 +146,7 @@ the ID of the journey.
 
 ##### Defined in
 
-[index.ts:123](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L123)
+[index.ts:123](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L123)
 
 ___
 
@@ -158,7 +158,7 @@ your workspace id
 
 ##### Defined in
 
-[index.ts:126](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L126)
+[index.ts:126](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L126)
 
 ___
 
@@ -172,7 +172,7 @@ _Note: This must be dynamically set by the voice bot._
 
 ##### Defined in
 
-[index.ts:133](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L133)
+[index.ts:133](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L133)
 
 ___
 
@@ -184,7 +184,7 @@ the user's language code, consistent with the language codes defined on the jour
 
 ##### Defined in
 
-[index.ts:138](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L138)
+[index.ts:138](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L138)
 
 ___
 
@@ -196,4 +196,4 @@ set to true to help debug issues or errors. Defaults to false
 
 ##### Defined in
 
-[index.ts:141](https://github.com/nlxai/sdk/blob/e92c6c48369da0688f12542ba524ad339d6d78f7/packages/multimodal/src/index.ts#L141)
+[index.ts:141](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/multimodal/src/index.ts#L141)

--- a/packages/website/src/content/07-02-journey-manager-api-reference.md
+++ b/packages/website/src/content/07-02-journey-manager-api-reference.md
@@ -7,7 +7,7 @@
 
 - [UrlCondition](#interfacesurlconditionmd)
 - [Trigger](#interfacestriggermd)
-- [ClickStep](#interfacesclickstepmd)
+- [StepWithQuery](#interfacesstepwithquerymd)
 - [ActiveTrigger](#interfacesactivetriggermd)
 - [RunOutput](#interfacesrunoutputmd)
 - [RunProps](#interfacesrunpropsmd)
@@ -29,7 +29,7 @@ Step ID
 
 #### Defined in
 
-[journey-manager/src/index.ts:22](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L22)
+[journey-manager/src/index.ts:22](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L22)
 
 ___
 
@@ -41,7 +41,19 @@ A record of triggers
 
 #### Defined in
 
-[journey-manager/src/index.ts:64](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L64)
+[journey-manager/src/index.ts:64](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L64)
+
+___
+
+### StepWithQueryAndElements
+
+Ƭ **StepWithQueryAndElements**: [`StepWithQuery`](#interfacesstepwithquerymd) & \{ `elements?`: `HTMLElement`[]  }
+
+Step with query and found elements
+
+#### Defined in
+
+[journey-manager/src/index.ts:97](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L97)
 
 ___
 
@@ -53,7 +65,7 @@ Active trigger event type.
 
 #### Defined in
 
-[journey-manager/src/index.ts:163](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L163)
+[journey-manager/src/index.ts:211](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L211)
 
 ___
 
@@ -65,7 +77,7 @@ Matching method
 
 #### Defined in
 
-[journey-manager/src/queries.ts:10](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L10)
+[journey-manager/src/queries.ts:10](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L10)
 
 ## Functions
 
@@ -89,7 +101,7 @@ an promise of an object containing a teardown function and the multimodal client
 
 #### Defined in
 
-[journey-manager/src/index.ts:261](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L261)
+[journey-manager/src/index.ts:309](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L309)
 
 
 <a name="indexmd"></a>
@@ -108,13 +120,13 @@ Active trigger.
 
 #### trigger
 
-• **trigger**: [`ClickStep`](#interfacesclickstepmd)
+• **trigger**: [`StepWithQuery`](#interfacesstepwithquerymd)
 
 The trigger associated with the elements.
 
 ##### Defined in
 
-[journey-manager/src/index.ts:170](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L170)
+[journey-manager/src/index.ts:218](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L218)
 
 ___
 
@@ -126,62 +138,7 @@ The matched elements
 
 ##### Defined in
 
-[journey-manager/src/index.ts:172](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L172)
-
-
-<a name="interfacesclickstepmd"></a>
-
-## Interface: ClickStep
-
-Click step
-
-### Properties
-
-#### stepId
-
-• **stepId**: `string`
-
-Step ID
-
-##### Defined in
-
-[journey-manager/src/index.ts:79](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L79)
-
-___
-
-#### query
-
-• **query**: [`Query`](#interfacesquerymd)
-
-Element query
-
-##### Defined in
-
-[journey-manager/src/index.ts:83](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L83)
-
-___
-
-#### once
-
-• `Optional` **once**: `boolean`
-
-Controls whether the step should only trigger the first time it is clicked, or on all subsequent clicks as well
-
-##### Defined in
-
-[journey-manager/src/index.ts:87](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L87)
-
-___
-
-#### urlCondition
-
-• `Optional` **urlCondition**: [`UrlCondition`](#interfacesurlconditionmd)
-
-URL condition for the click
-
-##### Defined in
-
-[journey-manager/src/index.ts:91](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L91)
+[journey-manager/src/index.ts:220](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L220)
 
 
 <a name="interfacesencodedquerymd"></a>
@@ -200,7 +157,7 @@ Query name
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:60](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L60)
+[journey-manager/src/queries.ts:60](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L60)
 
 ___
 
@@ -212,7 +169,7 @@ Query target
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:64](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L64)
+[journey-manager/src/queries.ts:64](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L64)
 
 ___
 
@@ -224,7 +181,7 @@ Query options
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:68](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L68)
+[journey-manager/src/queries.ts:68](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L68)
 
 ___
 
@@ -236,7 +193,7 @@ Query parent
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:72](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L72)
+[journey-manager/src/queries.ts:72](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L72)
 
 
 <a name="interfacespartialthememd"></a>
@@ -255,7 +212,7 @@ UI colors
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:47](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L47)
+[journey-manager/src/ui.tsx:47](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L47)
 
 ___
 
@@ -267,7 +224,7 @@ Font family
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:51](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L51)
+[journey-manager/src/ui.tsx:51](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L51)
 
 
 <a name="interfacesquerymd"></a>
@@ -286,7 +243,7 @@ Query name
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:28](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L28)
+[journey-manager/src/queries.ts:28](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L28)
 
 ___
 
@@ -298,7 +255,7 @@ Query arguments
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:32](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L32)
+[journey-manager/src/queries.ts:32](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L32)
 
 ___
 
@@ -310,7 +267,7 @@ Parent query
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:36](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L36)
+[journey-manager/src/queries.ts:36](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L36)
 
 
 <a name="interfacesrunoutputmd"></a>
@@ -337,7 +294,7 @@ Stop running the journey, removing all event listeners
 
 ##### Defined in
 
-[journey-manager/src/index.ts:182](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L182)
+[journey-manager/src/index.ts:230](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L230)
 
 ___
 
@@ -349,7 +306,7 @@ The regular multimodal SDK client
 
 ##### Defined in
 
-[journey-manager/src/index.ts:186](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L186)
+[journey-manager/src/index.ts:234](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L234)
 
 
 <a name="interfacesrunpropsmd"></a>
@@ -368,7 +325,7 @@ The regular multimodal configuration
 
 ##### Defined in
 
-[journey-manager/src/index.ts:196](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L196)
+[journey-manager/src/index.ts:244](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L244)
 
 ___
 
@@ -380,7 +337,7 @@ UI configuration
 
 ##### Defined in
 
-[journey-manager/src/index.ts:200](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L200)
+[journey-manager/src/index.ts:248](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L248)
 
 ___
 
@@ -393,7 +350,7 @@ If triggers are not provided, they will be fetched from the CDN.
 
 ##### Defined in
 
-[journey-manager/src/index.ts:205](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L205)
+[journey-manager/src/index.ts:253](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L253)
 
 ___
 
@@ -419,7 +376,7 @@ Digression detection callback
 
 ##### Defined in
 
-[journey-manager/src/index.ts:209](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L209)
+[journey-manager/src/index.ts:257](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L257)
 
 
 <a name="interfacesserializedregexmd"></a>
@@ -438,7 +395,7 @@ Regex body
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:46](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L46)
+[journey-manager/src/queries.ts:46](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L46)
 
 ___
 
@@ -450,7 +407,62 @@ Regex flags
 
 ##### Defined in
 
-[journey-manager/src/queries.ts:50](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/queries.ts#L50)
+[journey-manager/src/queries.ts:50](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/queries.ts#L50)
+
+
+<a name="interfacesstepwithquerymd"></a>
+
+## Interface: StepWithQuery
+
+Step with additional query
+
+### Properties
+
+#### stepId
+
+• **stepId**: `string`
+
+Step ID
+
+##### Defined in
+
+[journey-manager/src/index.ts:79](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L79)
+
+___
+
+#### query
+
+• **query**: [`Query`](#interfacesquerymd)
+
+Element query
+
+##### Defined in
+
+[journey-manager/src/index.ts:83](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L83)
+
+___
+
+#### once
+
+• `Optional` **once**: `boolean`
+
+Controls whether the step should only trigger the first time it is clicked, or on all subsequent clicks as well
+
+##### Defined in
+
+[journey-manager/src/index.ts:87](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L87)
+
+___
+
+#### urlCondition
+
+• `Optional` **urlCondition**: [`UrlCondition`](#interfacesurlconditionmd)
+
+URL condition for the click
+
+##### Defined in
+
+[journey-manager/src/index.ts:91](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L91)
 
 
 <a name="interfacesthememd"></a>
@@ -469,7 +481,7 @@ UI colors
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:33](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L33)
+[journey-manager/src/ui.tsx:33](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L33)
 
 ___
 
@@ -481,7 +493,7 @@ Font family
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:37](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L37)
+[journey-manager/src/ui.tsx:37](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L37)
 
 
 <a name="interfacesthemecolorsmd"></a>
@@ -500,7 +512,7 @@ Primary color
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:15](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L15)
+[journey-manager/src/ui.tsx:15](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L15)
 
 ___
 
@@ -512,7 +524,7 @@ Primary color on hover
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:19](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L19)
+[journey-manager/src/ui.tsx:19](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L19)
 
 ___
 
@@ -524,7 +536,7 @@ Color for trigger highlights
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:23](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L23)
+[journey-manager/src/ui.tsx:23](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L23)
 
 
 <a name="interfacestriggermd"></a>
@@ -537,13 +549,13 @@ A single trigger
 
 #### event
 
-• **event**: ``"click"`` \| ``"pageLoad"``
+• **event**: ``"click"`` \| ``"pageLoad"`` \| ``"appear"`` \| ``"enterViewport"``
 
 Event
 
 ##### Defined in
 
-[journey-manager/src/index.ts:46](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L46)
+[journey-manager/src/index.ts:46](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L46)
 
 ___
 
@@ -555,7 +567,7 @@ A query identifying the element
 
 ##### Defined in
 
-[journey-manager/src/index.ts:50](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L50)
+[journey-manager/src/index.ts:50](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L50)
 
 ___
 
@@ -567,7 +579,7 @@ A flag specifying whether the trigger should only fire a single time
 
 ##### Defined in
 
-[journey-manager/src/index.ts:54](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L54)
+[journey-manager/src/index.ts:54](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L54)
 
 ___
 
@@ -579,7 +591,7 @@ URL condition
 
 ##### Defined in
 
-[journey-manager/src/index.ts:58](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L58)
+[journey-manager/src/index.ts:58](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L58)
 
 
 <a name="interfacesuiconfigmd"></a>
@@ -598,7 +610,7 @@ Drawer title
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:61](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L61)
+[journey-manager/src/ui.tsx:61](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L61)
 
 ___
 
@@ -610,7 +622,7 @@ Drawer subtitle
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:65](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L65)
+[journey-manager/src/ui.tsx:65](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L65)
 
 ___
 
@@ -622,7 +634,7 @@ Render highlights
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:69](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L69)
+[journey-manager/src/ui.tsx:69](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L69)
 
 ___
 
@@ -634,31 +646,61 @@ UI theme
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:73](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L73)
+[journey-manager/src/ui.tsx:73](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L73)
 
 ___
 
-#### escalationStep
+#### onEscalation
 
-• `Optional` **escalationStep**: `string`
+• `Optional` **onEscalation**: (`config`: \{ `sendStep`: (`stepId`: `string`, `context?`: `Context`) => `Promise`\<`void`\>  }) => `void`
 
-Escalation step ID
+Escalation handler
+
+##### Type declaration
+
+▸ (`config`): `void`
+
+###### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `Object` |
+| `config.sendStep` | (`stepId`: `string`, `context?`: `Context`) => `Promise`\<`void`\> |
+
+###### Returns
+
+`void`
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:77](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L77)
+[journey-manager/src/ui.tsx:77](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L77)
 
 ___
 
-#### endStep
+#### onEnd
 
-• `Optional` **endStep**: `string`
+• `Optional` **onEnd**: (`config`: \{ `sendStep`: (`stepId`: `string`, `context?`: `Context`) => `Promise`\<`void`\>  }) => `void`
 
-End step ID
+End handler
+
+##### Type declaration
+
+▸ (`config`): `void`
+
+###### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `Object` |
+| `config.sendStep` | (`stepId`: `string`, `context?`: `Context`) => `Promise`\<`void`\> |
+
+###### Returns
+
+`void`
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:81](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L81)
+[journey-manager/src/ui.tsx:81](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L81)
 
 ___
 
@@ -686,7 +728,7 @@ On previous step
 
 ##### Defined in
 
-[journey-manager/src/ui.tsx:85](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/ui.tsx#L85)
+[journey-manager/src/ui.tsx:85](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/ui.tsx#L85)
 
 
 <a name="interfacesurlconditionmd"></a>
@@ -705,7 +747,7 @@ Condition operator
 
 ##### Defined in
 
-[journey-manager/src/index.ts:31](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L31)
+[journey-manager/src/index.ts:31](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L31)
 
 ___
 
@@ -717,4 +759,4 @@ Condition value
 
 ##### Defined in
 
-[journey-manager/src/index.ts:35](https://github.com/nlxai/sdk/blob/e6f65697e16134f7e08dae17f2a4ecc6197a3f32/packages/journey-manager/src/index.ts#L35)
+[journey-manager/src/index.ts:35](https://github.com/nlxai/sdk/blob/71307264e396822939eca86ed156fc2cc45d48d3/packages/journey-manager/src/index.ts#L35)


### PR DESCRIPTION
Providing this extra context with the request helps the NLU identify the node in question during conversation execution.