### PR TITLE
prototype of outline-style highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19714,6 +19714,7 @@
         "@testing-library/dom": "^10.1.0",
         "preact": "^10.22.0",
         "ramda": "^0.29.1",
+        "tinycolor2": "^1.6.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {

--- a/packages/journey-manager/package.json
+++ b/packages/journey-manager/package.json
@@ -44,6 +44,7 @@
     "@testing-library/dom": "^10.1.0",
     "preact": "^10.22.0",
     "ramda": "^0.29.1",
+    "tinycolor2": "^1.6.0",
     "uuid": "^9.0.1"
   },
   "publishConfig": {

--- a/packages/journey-manager/src/ui.tsx
+++ b/packages/journey-manager/src/ui.tsx
@@ -106,6 +106,32 @@ const mergeWithDefault = (partial?: PartialTheme): Theme => ({
   },
 });
 
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  // Remove the leading # if present
+  hex = hex.replace(/^#/, "");
+
+  // Check if the hex string is valid
+  if (hex.length !== 6 && hex.length !== 3) {
+    return null; // Invalid hex color
+  }
+
+  // If the hex string is shorthand (3 characters), convert it to 6 characters
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+
+  // Convert the hex values to RGB values
+  const bigint = parseInt(hex, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+
+  return { r, g, b };
+};
+
 const styles = (theme: Theme): string => `
 * {
   font-family: ${theme.fontFamily};
@@ -123,6 +149,9 @@ p {
   --primary: ${theme.colors.primary};
   --primary-hover: ${theme.colors.primaryHover};
   --highlight: ${theme.colors.highlight};
+  --highlightR: ${hexToRgb(theme.colors.highlight)?.r};
+  --highlightG: ${hexToRgb(theme.colors.highlight)?.g};
+  --highlightB: ${hexToRgb(theme.colors.highlight)?.b};
   z-index: 1000;
 }
 
@@ -319,37 +348,20 @@ button {
 
 /** Highlights */
 
+/* consider setting scale from javascript based on the size of the outlined element */
 @keyframes ping {
-  75%,
-  100% {
-    // consider setting scale from javascript based on the size of the outlined element
-    transform: scale(2);
-    opacity: 0;
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--highlightR), var(--highlightG), var(--highlightB), 0.8);
+  }
+  70% {
+    box-shadow: 0 0 0 8px rgba(var(--highlightR), var(--highlightG), var(--highlightB), 0);
   }
 }
 
 .highlight {
-  border-radius: 5%;
-  outline-color: var(--highlight);
-  outline-style: solid;
-  outline-width: 2px;
-  outline-offset: 1px;
   position: absolute;
-}
-
-.highlight::after {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  content: ' ';
-  border-radius: 5%;
-  outline-color: var(--highlight);
-  outline-width: 2px;
-  outline-style: solid;
-  outline-offset: 3px;
-  animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+  border-radius: 10%;
+  animation: ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 `;
 

--- a/packages/journey-manager/src/ui.tsx
+++ b/packages/journey-manager/src/ui.tsx
@@ -426,7 +426,6 @@ const Highlight: FunctionComponent<{ element: HTMLElement }> = ({
             floating: highlight,
             strategy: "absolute",
           });
-          console.log(reference);
           // platform.getElementRects is a `Promisable` rather than a `Promise` so we have to use await rather than .then
           setRect(reference);
         })();

--- a/packages/journey-manager/src/ui.tsx
+++ b/packages/journey-manager/src/ui.tsx
@@ -335,7 +335,7 @@ button {
 
 .highlight {
   position: absolute;
-  border-radius: 10%;
+  border-radius: 5px;
   animation: ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 `;
@@ -417,10 +417,10 @@ const Highlight: FunctionComponent<{ element: HTMLElement }> = ({
       style={
         rect != null
           ? {
-              top: `${rect.y}px`,
-              left: `${rect.x}px`,
-              height: `${rect.height}px`,
-              width: `${rect.width}px`,
+              top: `${rect.y - 1}px`,
+              left: `${rect.x - 1}px`,
+              height: `${rect.height + 2}px`,
+              width: `${rect.width + 2}px`,
             }
           : {}
       }

--- a/packages/journey-manager/src/ui.tsx
+++ b/packages/journey-manager/src/ui.tsx
@@ -324,7 +324,6 @@ button {
 
 /** Highlights */
 
-/* consider setting scale from javascript based on the size of the outlined element */
 @keyframes ping {
   0% {
     box-shadow: 0 0 0 0 rgba(var(--highlightR), var(--highlightG), var(--highlightB), 0.8);

--- a/packages/journey-manager/src/ui.tsx
+++ b/packages/journey-manager/src/ui.tsx
@@ -335,7 +335,6 @@ button {
 
 .highlight {
   position: absolute;
-  border-radius: 5px;
   animation: ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 `;
@@ -395,6 +394,21 @@ const Highlight: FunctionComponent<{ element: HTMLElement }> = ({
   useEffect(() => {
     if (ref.current != null) {
       const highlight = ref.current;
+
+      // copy over computed styles from element so drop shadow looks right
+      const computedStyles = window.getComputedStyle(element);
+
+      for (const property of computedStyles) {
+        if (!property.match(/^border/)) {
+          continue;
+        }
+
+        highlight.style.setProperty(
+          property,
+          computedStyles.getPropertyValue(property),
+        );
+      }
+
       const moveHighlight = (): void => {
         void (async (): Promise<void> => {
           const { reference } = await platform.getElementRects({

--- a/packages/journey-manager/src/ui.tsx
+++ b/packages/journey-manager/src/ui.tsx
@@ -4,6 +4,7 @@ import { type Client } from "@nlxai/multimodal";
 import { autoUpdate, platform } from "@floating-ui/dom";
 import { render, type FunctionComponent } from "preact";
 import { useEffect, useState, useRef, useMemo } from "preact/hooks";
+import tinycolor from "tinycolor2";
 
 /**
  * Theme colors
@@ -106,34 +107,10 @@ const mergeWithDefault = (partial?: PartialTheme): Theme => ({
   },
 });
 
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-  // Remove the leading # if present
-  hex = hex.replace(/^#/, "");
+const styles = (theme: Theme): string => {
+  const highlight = tinycolor(theme.colors.highlight).toRgb();
 
-  // Check if the hex string is valid
-  if (hex.length !== 6 && hex.length !== 3) {
-    return null; // Invalid hex color
-  }
-
-  // If the hex string is shorthand (3 characters), convert it to 6 characters
-  if (hex.length === 3) {
-    hex = hex
-      .split("")
-      .map((char) => char + char)
-      .join("");
-  }
-
-  // Convert the hex values to RGB values
-  const bigint = parseInt(hex, 16);
-  const r = (bigint >> 16) & 255;
-  const g = (bigint >> 8) & 255;
-  const b = bigint & 255;
-
-  return { r, g, b };
-};
-
-const styles = (theme: Theme): string => `
-* {
+  return `* {
   font-family: ${theme.fontFamily};
   font-size: 14px;
 }
@@ -148,10 +125,9 @@ p {
 .highlights {
   --primary: ${theme.colors.primary};
   --primary-hover: ${theme.colors.primaryHover};
-  --highlight: ${theme.colors.highlight};
-  --highlightR: ${hexToRgb(theme.colors.highlight)?.r};
-  --highlightG: ${hexToRgb(theme.colors.highlight)?.g};
-  --highlightB: ${hexToRgb(theme.colors.highlight)?.b};
+  --highlightR: ${highlight.r};
+  --highlightG: ${highlight.g};
+  --highlightB: ${highlight.b};
   z-index: 1000;
 }
 
@@ -364,6 +340,7 @@ button {
   animation: ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 `;
+};
 
 const MultimodalIcon: FunctionComponent<unknown> = () => (
   <svg viewBox="0 0 24 24" stroke="none" fill="currentColor">

--- a/packages/website/src/components/Prototyping.tsx
+++ b/packages/website/src/components/Prototyping.tsx
@@ -118,6 +118,7 @@ const runJourneyManager = async (): Promise<unknown> => {
       highlights: true,
       theme: {
         fontFamily: "'Neue Haas Grotesk'",
+        colors: { highlight: "#42f5d4" },
       },
       onEscalation: () => {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
![CleanShot 2024-07-18 at 12 18 35](https://github.com/user-attachments/assets/f4948511-8c6b-44cc-ae57-94495301a40f)


implements FRO-79

To the reviewer: should we stop creating a highlight element and ONLY style the existing element with a blinking drop shadow? Or will that be less compatible? I guess if we style the existing element, the element borders will be less janky (and in general, the complexity of the whole implementation should be simpler save for the one thousand edge cases)