### PR TITLE
Adds a more robust box-shadow highlight strategy

### DIFF
--- a/packages/journey-manager/src/configuration.ts
+++ b/packages/journey-manager/src/configuration.ts
@@ -90,6 +90,11 @@ export interface UiConfig {
    * Render highlights
    */
   highlights?: boolean;
+
+  /**
+   * @hidden
+   */
+  highlightStrategy?: "overlay" | "box-shadow";
   /**
    * URL for the button icon
    */

--- a/packages/journey-manager/src/ui/components/HighlightOverlay.tsx
+++ b/packages/journey-manager/src/ui/components/HighlightOverlay.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable jsdoc/require-jsdoc */
+import { autoUpdate, platform } from "@floating-ui/dom";
+import { type FunctionComponent as FC } from "preact";
+import { useEffect, useState, useRef } from "preact/hooks";
+
+export const Highlight: FC<{
+  element: HTMLElement;
+}> = ({ element }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [rect, setRect] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (ref.current != null) {
+      const highlight = ref.current;
+
+      // copy over computed styles from element so drop shadow looks right
+      const computedStyles = window.getComputedStyle(element);
+
+      for (const property of computedStyles) {
+        if (!property.match(/^border/)) {
+          continue;
+        }
+
+        highlight.style.setProperty(
+          property,
+          computedStyles.getPropertyValue(property),
+        );
+      }
+
+      const moveHighlight = (): void => {
+        void (async (): Promise<void> => {
+          const { reference } = await platform.getElementRects({
+            reference: element,
+            floating: highlight,
+            strategy: "absolute",
+          });
+          // platform.getElementRects is a `Promisable` rather than a `Promise` so we have to use await rather than .then
+          setRect(reference);
+        })();
+      };
+
+      return autoUpdate(element, highlight, moveHighlight);
+    }
+  }, [element]);
+
+  return (
+    <div
+      className="highlight"
+      ref={ref}
+      style={
+        rect != null
+          ? {
+              top: `${rect.y - 1}px`,
+              left: `${rect.x - 1}px`,
+              height: `${rect.height + 2}px`,
+              width: `${rect.width + 2}px`,
+            }
+          : {}
+      }
+    ></div>
+  );
+};

--- a/packages/journey-manager/src/ui/custom-element.tsx
+++ b/packages/journey-manager/src/ui/custom-element.tsx
@@ -9,6 +9,7 @@ import type { UiConfig, TriggeredStep } from "../configuration";
  */
 export default class JourneyManagerElement extends HTMLElement {
   private _shadowRoot: ShadowRoot | null = null;
+  private readonly _globalCss: HTMLStyleElement | null = null;
   private _client: Client | null = null;
   private _triggeredSteps: TriggeredStep[] | null = null;
   private _config: UiConfig | null = null;
@@ -87,6 +88,9 @@ export default class JourneyManagerElement extends HTMLElement {
   disconnectedCallback(): void {
     if (this._shadowRoot != null) {
       render(null, this._shadowRoot);
+    }
+    if (this._globalCss != null) {
+      this._globalCss.remove();
     }
   }
 }

--- a/packages/journey-manager/src/ui/custom-element.tsx
+++ b/packages/journey-manager/src/ui/custom-element.tsx
@@ -9,7 +9,6 @@ import type { UiConfig, TriggeredStep } from "../configuration";
  */
 export default class JourneyManagerElement extends HTMLElement {
   private _shadowRoot: ShadowRoot | null = null;
-  private readonly _globalCss: HTMLStyleElement | null = null;
   private _client: Client | null = null;
   private _triggeredSteps: TriggeredStep[] | null = null;
   private _config: UiConfig | null = null;
@@ -88,9 +87,6 @@ export default class JourneyManagerElement extends HTMLElement {
   disconnectedCallback(): void {
     if (this._shadowRoot != null) {
       render(null, this._shadowRoot);
-    }
-    if (this._globalCss != null) {
-      this._globalCss.remove();
     }
   }
 }

--- a/packages/journey-manager/src/ui/global.css
+++ b/packages/journey-manager/src/ui/global.css
@@ -1,0 +1,65 @@
+.nlx-highlight-no-shadow-no-animation {
+  animation: nlx-ping-no-shadow 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+.nlx-highlight-no-shadow-existing-animation {
+  animation:
+    var(--nlx-existing-animation),
+    nlx-ping-no-shadow 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+.nlx-highlight-existing-shadow-no-animation {
+  animation: nlx-ping-existing-shadow 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+.nlx-highlight-existing-shadow-existing-animation {
+  animation:
+    var(--nlx-existing-animation),
+    nlx-ping-existing-shadow 1.5s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@keyframes nlx-ping-no-shadow {
+  0% {
+    box-shadow: 0 0 0 0
+      rgba(
+        var(--nlx-highlightR),
+        var(--nlx-highlightG),
+        var(--nlx-highlightB),
+        0.8
+      );
+  }
+  70% {
+    box-shadow: 0 0 0 8px
+      rgba(
+        var(--nlx-highlightR),
+        var(--nlx-highlightG),
+        var(--nlx-highlightB),
+        0
+      );
+  }
+}
+
+@keyframes nlx-ping-existing-shadow {
+  0% {
+    box-shadow:
+      var(--nlx-existing-box-shadow),
+      0 0 0 0
+        rgba(
+          var(--nlx-highlightR),
+          var(--nlx-highlightG),
+          var(--nlx-highlightB),
+          0.8
+        );
+  }
+  70% {
+    box-shadow:
+      var(--nlx-existing-box-shadow),
+      0 0 0 8px
+        rgba(
+          var(--nlx-highlightR),
+          var(--nlx-highlightG),
+          var(--nlx-highlightB),
+          0
+        );
+  }
+}

--- a/packages/journey-manager/src/ui/highlightBoxShadow.ts
+++ b/packages/journey-manager/src/ui/highlightBoxShadow.ts
@@ -1,0 +1,96 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import tinycolor from "tinycolor2";
+import type { UiConfig } from "../configuration";
+import global from "./global.css";
+
+export const createGlobalStyles = (
+  config: UiConfig,
+): HTMLStyleElement | null => {
+  if (config.highlightStrategy !== "overlay") {
+    const highlight = tinycolor(
+      config.theme?.colors?.highlight ?? "rgba(38, 99, 218, 1)",
+    ).toRgb();
+    const style = document.createElement("style");
+    style.textContent = `
+      * {--nlx-highlightR: ${highlight.r};--nlx-highlightG: ${highlight.g};--nlx-highlightB: ${highlight.b};}${global}`;
+    document.head.appendChild(style);
+    return style;
+  }
+  return null;
+};
+
+const possibleClasses = [
+  "nlx-highlight-no-shadow-no-animation",
+  "nlx-highlight-no-shadow-existing-animation",
+  "nlx-highlight-existing-shadow-no-animation",
+  "nlx-highlight-existing-shadow-existing-animation",
+];
+
+const applyHighlight = (element: HTMLElement): HTMLElement => {
+  if (
+    !possibleClasses.some((className) => element.classList.contains(className))
+  ) {
+    const computedStyles = window.getComputedStyle(element);
+    const boxShadow = computedStyles.getPropertyValue("box-shadow");
+    const animation = computedStyles.getPropertyValue("animation-name");
+
+    if (boxShadow === "none" && animation === "none") {
+      element.classList.add("nlx-highlight-no-shadow-no-animation");
+    } else if (animation === "none") {
+      element.style.setProperty("--nlx-existing-box-shadow", boxShadow);
+      element.classList.add("nlx-highlight-existing-shadow-no-animation");
+    } else if (boxShadow === "none") {
+      element.style.setProperty(
+        "--nlx-existing-animation",
+        computedStyles.getPropertyValue("animation"),
+      );
+      element.classList.add("nlx-highlight-no-shadow-existing-animation");
+    } else {
+      element.style.setProperty("--nlx-existing-box-shadow", boxShadow);
+      element.style.setProperty(
+        "--nlx-existing-animation",
+        computedStyles.getPropertyValue("animation"),
+      );
+      element.classList.add("nlx-highlight-existing-shadow-existing-animation");
+    }
+  }
+
+  return element;
+};
+
+const cleanup = (element: HTMLElement): void => {
+  element.style.removeProperty("--nlx-existing-box-shadow");
+  element.style.removeProperty("--nlx-existing-animation");
+  element.classList.remove(...possibleClasses);
+};
+
+let prevElements: HTMLElement[] = [];
+let timeout: number | null = null;
+let styleTag: HTMLElement | null = null;
+
+export default (config: UiConfig, highlightElements: HTMLElement[]): void => {
+  if (timeout != null) {
+    window.clearTimeout(timeout);
+  }
+  timeout = window.setTimeout(() => {
+    if (styleTag == null) {
+      styleTag = createGlobalStyles(config);
+    }
+    prevElements
+      .filter((element) => !highlightElements.includes(element))
+      .forEach(cleanup);
+    prevElements = highlightElements.map(applyHighlight);
+
+    timeout = null;
+  }, 100);
+};
+
+export const teardown = (): void => {
+  if (timeout != null) {
+    window.clearTimeout(timeout);
+  }
+  if (styleTag != null) {
+    styleTag.remove();
+  }
+  prevElements.forEach(cleanup);
+};

--- a/packages/journey-manager/src/ui/index.tsx
+++ b/packages/journey-manager/src/ui/index.tsx
@@ -6,6 +6,9 @@ import type {
   ActiveTriggerEventType,
   StepWithQueryAndElements,
 } from "../trigger";
+import highlightBoxShadow, {
+  teardown as teardownBoxShadowHighlight,
+} from "./highlightBoxShadow";
 
 customElements.define("journey-manager", JourneyManagerElement);
 
@@ -44,8 +47,10 @@ const create = (
           const highlightElements = findActiveTriggers("click").flatMap(
             (activeTrigger) => activeTrigger.elements,
           );
-          if (uiElement != null) {
+          if (uiElement != null && config.highlightStrategy === "overlay") {
             uiElement.highlightElements = highlightElements;
+          } else {
+            highlightBoxShadow(config, highlightElements);
           }
         }
       : () => {};
@@ -62,6 +67,8 @@ const create = (
       },
       teardown() {
         document.body.removeChild(uiElement);
+        if (config.highlightStrategy !== "overlay")
+          teardownBoxShadowHighlight();
       },
     };
   }

--- a/packages/journey-manager/src/utils/dom.ts
+++ b/packages/journey-manager/src/utils/dom.ts
@@ -80,6 +80,7 @@ export const observeMutations = (callback: MutationCallback) => {
   documentObserver.observe(document, {
     childList: true,
     subtree: true,
+    attributes: true,
   });
 
   return () => {

--- a/packages/website/src/components/Prototyping.tsx
+++ b/packages/website/src/components/Prototyping.tsx
@@ -98,7 +98,12 @@ const triggersWithNames: Record<string, { name: string; trigger: Trigger }> = {
       event: "click",
       once: false,
       query: {
-        parent: null,
+        parent: {
+          name: "LabelText",
+          target: "Custom button form",
+          options: null,
+          parent: null,
+        },
         options: { name: { regexp: "Test", flags: "i" } },
         name: "Role",
         target: "button",
@@ -129,6 +134,7 @@ const runJourneyManager = async (): Promise<unknown> => {
       title: "Call Control Center",
       subtitle: "Manage your call experience with us",
       highlights: true,
+      // highlightStrategy: "overlay",
       theme: {
         fontFamily: "'Neue Haas Grotesk'",
         colors: { highlight: "#7dd3fc" },
@@ -223,6 +229,8 @@ const ButtonHandlerForm: FC<unknown> = () => {
   const [hasOverlay, setHasOverlay] = useState<boolean>(false);
   const [hasBorder, setHasBorder] = useState<boolean>(true);
 
+  const [shouldMatch, setShouldMatch] = useState<boolean>(true);
+
   const handleButtonPress = (e: React.MouseEvent<HTMLButtonElement>): void => {
     if (shouldPreventDefault) {
       e.preventDefault();
@@ -233,7 +241,10 @@ const ButtonHandlerForm: FC<unknown> = () => {
   };
 
   return (
-    <div className="flex gap-2 items-start grow justify-around">
+    <div
+      className="flex gap-2 items-start grow justify-around"
+      aria-label={shouldMatch ? "Custom button form" : ""}
+    >
       <div
         className={
           hasZIndexUnderlay
@@ -289,6 +300,12 @@ const ButtonHandlerForm: FC<unknown> = () => {
           label="Absolute overlay"
         />
         <Checkbox value={hasBorder} onChange={setHasBorder} label="Border" />
+
+        <Checkbox
+          value={shouldMatch}
+          onChange={setShouldMatch}
+          label="Trigger matches"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
This now seems to work in all the scenarios I could think of... So in this branch this strategy is enabled by default. However, you can change this default by passing `highlightStrategy: 'overlay'` to the config.