### PR TITLE
since head is more reliable for me than --since

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish-docs": "lerna run publish-docs",
     "test": "lerna run test && cd test-repos/chat-core && npm install && npm run test",
     "tsc": "lerna run tsc",
-    "watch": "lerna watch -- lerna run build --since"
+    "watch": "lerna watch -- lerna run build --since HEAD"
   },
   "author": "Peter Szerzo <peter@nlx.ai>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish-docs": "lerna run publish-docs",
     "test": "lerna run test && cd test-repos/chat-core && npm install && npm run test",
     "tsc": "lerna run tsc",
-    "watch": "lerna watch -- lerna run build --since HEAD"
+    "watch": "lerna watch -- lerna run build --since HEAD --ignore @nlxai/website"
   },
   "author": "Peter Szerzo <peter@nlx.ai>",
   "license": "MIT",


### PR DESCRIPTION
I've often run `npm run watch` and have it not pick up changes.

This change has made it more reliable for me.

(once upon a time I did the research to know exactly why but I'm not spending the cycles right now. We can always roll back if it causes problems)

additionally I ignore building website from watch, because we use `npm run dev` for that