### PR TITLE
Publish touchpoint ui jsdocs

### DIFF
--- a/packages/touchpoint-ui/docs/.nojekyll
+++ b/packages/touchpoint-ui/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/packages/touchpoint-ui/docs/README.md
+++ b/packages/touchpoint-ui/docs/README.md
@@ -1,0 +1,259 @@
+# @nlxai/touchpoint-ui
+
+## Namespaces
+
+- [Icons](modules/Icons.md)
+
+## Interfaces
+
+- [TouchpointInstance](interfaces/TouchpointInstance.md)
+
+## Functions
+
+### Carousel
+
+▸ **Carousel**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Carousel.tsx:5](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Carousel.tsx#L5)
+
+___
+
+### CustomCard
+
+▸ **CustomCard**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `CustomCardProps` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:13](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L13)
+
+___
+
+### CustomCardImageRow
+
+▸ **CustomCardImageRow**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.src` | `string` | - |
+| `props.alt?` | `string` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:32](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L32)
+
+___
+
+### CustomCardRow
+
+▸ **CustomCardRow**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `CustomCardRowProps` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:45](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L45)
+
+___
+
+### DateInput
+
+▸ **DateInput**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `DateInputProps` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/DateInput.tsx:17](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L17)
+
+___
+
+### IconButton
+
+▸ **IconButton**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `IconButtonProps` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:37](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L37)
+
+___
+
+### TextButton
+
+▸ **TextButton**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `TextButtonProps` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:14](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L14)
+
+___
+
+### BaseText
+
+▸ **BaseText**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `props.faded?` | `boolean` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Typography.tsx:5](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Typography.tsx#L5)
+
+___
+
+### SmallText
+
+▸ **SmallText**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Typography.tsx:16](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Typography.tsx#L16)
+
+___
+
+### useTouchpointContext
+
+▸ **useTouchpointContext**(): `ContextValue`
+
+#### Returns
+
+`ContextValue`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/context.ts:13](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/context.ts#L13)
+
+___
+
+### html
+
+▸ **html**(`strings`, `...values`): `unknown`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `strings` | `TemplateStringsArray` |
+| `...values` | `any`[] |
+
+#### Returns
+
+`unknown`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:33](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/index.tsx#L33)
+
+___
+
+### create
+
+▸ **create**(`props`): [`TouchpointInstance`](interfaces/TouchpointInstance.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Props` |
+
+#### Returns
+
+[`TouchpointInstance`](interfaces/TouchpointInstance.md)
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:108](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/index.tsx#L108)

--- a/packages/touchpoint-ui/docs/interfaces/Icons.IconProps.md
+++ b/packages/touchpoint-ui/docs/interfaces/Icons.IconProps.md
@@ -1,0 +1,23 @@
+# Interface: IconProps
+
+[Icons](../modules/Icons.md).IconProps
+
+## Properties
+
+### className
+
+• `Optional` **className**: `string`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:5](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L5)
+
+___
+
+### size
+
+• `Optional` **size**: `number`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:6](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L6)

--- a/packages/touchpoint-ui/docs/interfaces/TouchpointInstance.md
+++ b/packages/touchpoint-ui/docs/interfaces/TouchpointInstance.md
@@ -1,0 +1,73 @@
+# Interface: TouchpointInstance
+
+## Properties
+
+### expand
+
+• **expand**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:102](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/index.tsx#L102)
+
+___
+
+### collapse
+
+• **collapse**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:103](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/index.tsx#L103)
+
+___
+
+### getConversationHandler
+
+• **getConversationHandler**: () => ``null`` \| `ConversationHandler`
+
+#### Type declaration
+
+▸ (): ``null`` \| `ConversationHandler`
+
+##### Returns
+
+``null`` \| `ConversationHandler`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:104](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/index.tsx#L104)
+
+___
+
+### teardown
+
+• **teardown**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:105](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/index.tsx#L105)

--- a/packages/touchpoint-ui/docs/modules/Icons.md
+++ b/packages/touchpoint-ui/docs/modules/Icons.md
@@ -1,0 +1,855 @@
+# Namespace: Icons
+
+## Interfaces
+
+- [IconProps](../interfaces/Icons.IconProps.md)
+
+## Type Aliases
+
+### Icon
+
+Ƭ **Icon**: `FC`\<[`IconProps`](../interfaces/Icons.IconProps.md)\>
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:9](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L9)
+
+## Functions
+
+### Action
+
+▸ **Action**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:17](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L17)
+
+___
+
+### Assistant
+
+▸ **Assistant**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:28](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L28)
+
+___
+
+### AssistantOld
+
+▸ **AssistantOld**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:55](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L55)
+
+___
+
+### Add
+
+▸ **Add**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:66](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L66)
+
+___
+
+### ArrowDown
+
+▸ **ArrowDown**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:74](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L74)
+
+___
+
+### ArrowLeft
+
+▸ **ArrowLeft**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:85](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L85)
+
+___
+
+### ArrowRight
+
+▸ **ArrowRight**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:96](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L96)
+
+___
+
+### ArrowUp
+
+▸ **ArrowUp**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:107](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L107)
+
+___
+
+### ArrowForward
+
+▸ **ArrowForward**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:118](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L118)
+
+___
+
+### Attachment
+
+▸ **Attachment**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:129](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L129)
+
+___
+
+### Camera
+
+▸ **Camera**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:140](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L140)
+
+___
+
+### Check
+
+▸ **Check**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:155](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L155)
+
+___
+
+### Close
+
+▸ **Close**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:166](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L166)
+
+___
+
+### Copy
+
+▸ **Copy**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:177](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L177)
+
+___
+
+### Date
+
+▸ **Date**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:188](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L188)
+
+___
+
+### Delete
+
+▸ **Delete**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:199](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L199)
+
+___
+
+### Escalate
+
+▸ **Escalate**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:213](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L213)
+
+___
+
+### Error
+
+▸ **Error**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:236](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L236)
+
+___
+
+### FullScreen
+
+▸ **FullScreen**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:247](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L247)
+
+___
+
+### Mic
+
+▸ **Mic**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:258](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L258)
+
+___
+
+### MicOff
+
+▸ **MicOff**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:269](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L269)
+
+___
+
+### Location
+
+▸ **Location**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:280](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L280)
+
+___
+
+### Volume
+
+▸ **Volume**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:291](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L291)
+
+___
+
+### VolumeOff
+
+▸ **VolumeOff**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:302](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L302)
+
+___
+
+### Translate
+
+▸ **Translate**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:313](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L313)
+
+___
+
+### OpenInNew
+
+▸ **OpenInNew**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:324](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L324)
+
+___
+
+### Play
+
+▸ **Play**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:335](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L335)
+
+___
+
+### Preview
+
+▸ **Preview**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:343](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L343)
+
+___
+
+### Reorder
+
+▸ **Reorder**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:360](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L360)
+
+___
+
+### Restart
+
+▸ **Restart**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:371](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L371)
+
+___
+
+### Settings
+
+▸ **Settings**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:382](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L382)
+
+___
+
+### Search
+
+▸ **Search**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:393](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L393)
+
+___
+
+### Share
+
+▸ **Share**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:404](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L404)
+
+___
+
+### Warning
+
+▸ **Warning**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:415](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L415)
+
+___
+
+### ThumbDown
+
+▸ **ThumbDown**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:426](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L426)
+
+___
+
+### ThumbUp
+
+▸ **ThumbUp**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:437](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L437)
+
+___
+
+### Time
+
+▸ **Time**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:448](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L448)
+
+___
+
+### Undo
+
+▸ **Undo**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:465](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L465)
+
+___
+
+### Refresh
+
+▸ **Refresh**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:476](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L476)
+
+___
+
+### Help
+
+▸ **Help**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](../interfaces/Icons.IconProps.md) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:487](https://github.com/nlxai/sdk/blob/60e620aa63af0aaf7be7fdadaae144688b13d156/packages/touchpoint-ui/src/components/ui/Icons.tsx#L487)

--- a/packages/touchpoint-ui/typedoc.cjs
+++ b/packages/touchpoint-ui/typedoc.cjs
@@ -1,0 +1,14 @@
+/** @type { import('typedoc').TypeDocOptions & { hideInPageTOC?: boolean, hideBreadcrumbs?: boolean} } */
+module.exports = {
+  entryPoints: ["./src/index.tsx"],
+  hideBreadcrumbs: true,
+  hideInPageTOC: true,
+  out: "docs",
+  plugin: ["typedoc-plugin-markdown"],
+  readme: "none",
+  sort: ["source-order", "kind", "instance-first", "alphabetical"],
+  // TODO: figure out a way to sort out warnings and set the following two flags to 'true' again (consistent with the other packages)
+  treatValidationWarningsAsErrors: false,
+  treatWarningsAsErrors: false,
+  validation: { notExported: true, invalidLink: true, notDocumented: true },
+};

--- a/packages/touchpoint-ui/typedoc.cjs
+++ b/packages/touchpoint-ui/typedoc.cjs
@@ -1,5 +1,6 @@
 /** @type { import('typedoc').TypeDocOptions & { hideInPageTOC?: boolean, hideBreadcrumbs?: boolean} } */
 module.exports = {
+  excludeExternals: true,
   entryPoints: ["./src/index.tsx"],
   hideBreadcrumbs: true,
   hideInPageTOC: true,


### PR DESCRIPTION
Current issues:
- the documentation exports 296k lines 😨 (might be importing React stuff)
- typedoc configuration warnings handling had to be loosened