### PR TITLE
fix markdown anchor links

### DIFF
--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -71,7 +71,6 @@ export const PageContent: FC<{ md: string; className?: string }> = ({
             const name: string | undefined = (props as unknown as any).name;
             // eslint-disable-next-line react/prop-types
             if (props.href == null && name != null) {
-              // eslint-disable-next-line react/prop-types
               return <a id={name}>{props.children}</a>;
             }
             // TODO: when using a react-router redirect, scroll to heading ID if available

--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -66,11 +66,12 @@ export const PageContent: FC<{ md: string; className?: string }> = ({
         rehypePlugins={[rehypeRaw, rehypeSlug]}
         components={{
           a(props) {
-            // JSDOC output contains markup such as <a name="interfacespropsmd"></a>, so the `name` attribute shows up even if the
+            // `concat-md` output contains markup such as <a name="interfacespropsmd"></a> as anchor targets. However, react types don't expect the (basically deprecated) `name` attribute, hence the `as unknown as any` hack.
             // markdown package typings expect it not to.
             const name: string | undefined = (props as unknown as any).name;
             // eslint-disable-next-line react/prop-types
             if (props.href == null && name != null) {
+              // redefine `name` as `id` as suggested in the MDN for anchor targets.
               return <a id={name}>{props.children}</a>;
             }
             // TODO: when using a react-router redirect, scroll to heading ID if available

--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -58,61 +58,63 @@ export const Prose: FC<{ children: ReactNode; className?: string }> = ({
 export const PageContent: FC<{ md: string; className?: string }> = ({
   md,
   className,
-}) => (
-  <Prose className={className}>
-    <Markdown
-      remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeRaw, rehypeSlug]}
-      components={{
-        a(props) {
-          const name: string | undefined = (props as unknown as any).name;
-          // eslint-disable-next-line react/prop-types
-          if (props.href == null && name != null) {
+}) => {
+  return (
+    <Prose className={className}>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeSlug]}
+        components={{
+          a(props) {
+            const name: string | undefined = (props as unknown as any).name;
             // eslint-disable-next-line react/prop-types
-            return <a id={name}>{props.children}</a>;
-          }
-          // TODO: when using a react-router redirect, scroll to heading ID if available
-          // eslint-disable-next-line react/prop-types
-          return <Link to={props.href ?? ""}>{props.children}</Link>;
-        },
-        pre(props) {
-          return (
-            <pre className="relative group !font-mono">{props.children}</pre>
-          );
-        },
-        code(props) {
-          // initial eslint integration
-          // eslint-disable-next-line react/prop-types
-          const { children, className, node, ...rest } = props;
-          const match = /language-(\w+)/.exec(className ?? "");
-          const lines = String(children).replace(/\n$/, "");
-          return (
-            <>
-              <CopyToClipboardButton
-                text={lines}
-                className="absolute top-1.5 right-1.5 hidden group-hover:block"
-              />
-              {match ? (
-                <SyntaxHighlighter
-                  style={{}}
-                  useInlineStyles={false}
-                  showLineNumbers={true}
-                  language={match[1]}
-                  PreTag="div"
-                >
-                  {lines}
-                </SyntaxHighlighter>
-              ) : (
-                <code {...rest} className={className}>
-                  {children}
-                </code>
-              )}
-            </>
-          );
-        },
-      }}
-    >
-      {md}
-    </Markdown>
-  </Prose>
-);
+            if (props.href == null && name != null) {
+              // eslint-disable-next-line react/prop-types
+              return <a id={name}>{props.children}</a>;
+            }
+            // TODO: when using a react-router redirect, scroll to heading ID if available
+            // eslint-disable-next-line react/prop-types
+            return <Link to={props.href ?? ""}>{props.children}</Link>;
+          },
+          pre(props) {
+            return (
+              <pre className="relative group !font-mono">{props.children}</pre>
+            );
+          },
+          code(props) {
+            // initial eslint integration
+            // eslint-disable-next-line react/prop-types
+            const { children, className, node, ...rest } = props;
+            const match = /language-(\w+)/.exec(className ?? "");
+            const lines = String(children).replace(/\n$/, "");
+            return (
+              <>
+                <CopyToClipboardButton
+                  text={lines}
+                  className="absolute top-1.5 right-1.5 hidden group-hover:block"
+                />
+                {match ? (
+                  <SyntaxHighlighter
+                    style={{}}
+                    useInlineStyles={false}
+                    showLineNumbers={true}
+                    language={match[1]}
+                    PreTag="div"
+                  >
+                    {lines}
+                  </SyntaxHighlighter>
+                ) : (
+                  <code {...rest} className={className}>
+                    {children}
+                  </code>
+                )}
+              </>
+            );
+          },
+        }}
+      >
+        {md}
+      </Markdown>
+    </Prose>
+  );
+};

--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -58,62 +58,60 @@ export const Prose: FC<{ children: ReactNode; className?: string }> = ({
 export const PageContent: FC<{ md: string; className?: string }> = ({
   md,
   className,
-}) => {
-  return (
-    <Prose className={className}>
-      <Markdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, rehypeSlug]}
-        components={{
-          a(props) {
+}) => (
+  <Prose className={className}>
+    <Markdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, rehypeSlug]}
+      components={{
+        a(props) {
+          // eslint-disable-next-line react/prop-types
+          if (props.href == null && props.name != null) {
             // eslint-disable-next-line react/prop-types
-            if (props.href == null) {
-              // eslint-disable-next-line react/prop-types
-              return <a href={props.href}>{props.children}</a>;
-            }
-            // TODO: when using a react-router redirect, scroll to heading ID if available
-            // eslint-disable-next-line react/prop-types
-            return <Link to={props.href}>{props.children}</Link>;
-          },
-          pre(props) {
-            return (
-              <pre className="relative group !font-mono">{props.children}</pre>
-            );
-          },
-          code(props) {
-            // initial eslint integration
-            // eslint-disable-next-line react/prop-types
-            const { children, className, node, ...rest } = props;
-            const match = /language-(\w+)/.exec(className ?? "");
-            const lines = String(children).replace(/\n$/, "");
-            return (
-              <>
-                <CopyToClipboardButton
-                  text={lines}
-                  className="absolute top-1.5 right-1.5 hidden group-hover:block"
-                />
-                {match ? (
-                  <SyntaxHighlighter
-                    style={{}}
-                    useInlineStyles={false}
-                    showLineNumbers={true}
-                    language={match[1]}
-                    PreTag="div"
-                  >
-                    {lines}
-                  </SyntaxHighlighter>
-                ) : (
-                  <code {...rest} className={className}>
-                    {children}
-                  </code>
-                )}
-              </>
-            );
-          },
-        }}
-      >
-        {md}
-      </Markdown>
-    </Prose>
-  );
-};
+            return <a id={props.name}>{props.children}</a>;
+          }
+          // TODO: when using a react-router redirect, scroll to heading ID if available
+          // eslint-disable-next-line react/prop-types
+          return <Link to={props.href}>{props.children}</Link>;
+        },
+        pre(props) {
+          return (
+            <pre className="relative group !font-mono">{props.children}</pre>
+          );
+        },
+        code(props) {
+          // initial eslint integration
+          // eslint-disable-next-line react/prop-types
+          const { children, className, node, ...rest } = props;
+          const match = /language-(\w+)/.exec(className ?? "");
+          const lines = String(children).replace(/\n$/, "");
+          return (
+            <>
+              <CopyToClipboardButton
+                text={lines}
+                className="absolute top-1.5 right-1.5 hidden group-hover:block"
+              />
+              {match ? (
+                <SyntaxHighlighter
+                  style={{}}
+                  useInlineStyles={false}
+                  showLineNumbers={true}
+                  language={match[1]}
+                  PreTag="div"
+                >
+                  {lines}
+                </SyntaxHighlighter>
+              ) : (
+                <code {...rest} className={className}>
+                  {children}
+                </code>
+              )}
+            </>
+          );
+        },
+      }}
+    >
+      {md}
+    </Markdown>
+  </Prose>
+);

--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -65,14 +65,15 @@ export const PageContent: FC<{ md: string; className?: string }> = ({
       rehypePlugins={[rehypeRaw, rehypeSlug]}
       components={{
         a(props) {
+          const name: string | undefined = (props as unknown as any).name;
           // eslint-disable-next-line react/prop-types
-          if (props.href == null && props.name != null) {
+          if (props.href == null && name != null) {
             // eslint-disable-next-line react/prop-types
-            return <a id={props.name}>{props.children}</a>;
+            return <a id={name}>{props.children}</a>;
           }
           // TODO: when using a react-router redirect, scroll to heading ID if available
           // eslint-disable-next-line react/prop-types
-          return <Link to={props.href}>{props.children}</Link>;
+          return <Link to={props.href ?? ""}>{props.children}</Link>;
         },
         pre(props) {
           return (

--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -66,6 +66,8 @@ export const PageContent: FC<{ md: string; className?: string }> = ({
         rehypePlugins={[rehypeRaw, rehypeSlug]}
         components={{
           a(props) {
+            // JSDOC output contains markup such as <a name="interfacespropsmd"></a>, so the `name` attribute shows up even if the
+            // markdown package typings expect it not to.
             const name: string | undefined = (props as unknown as any).name;
             // eslint-disable-next-line react/prop-types
             if (props.href == null && name != null) {


### PR DESCRIPTION
I _guess_ this was a regression introduced in https://github.com/nlxai/sdk/commit/7be6c3d5c198069cb3b9d2a4553733b739e6bdb8 but I have no confirmed that.

The markdown code had named anchor tags that were stripped out.

After this commit, I believe markdown anchors work again.