### PR TITLE
Fix node@22 build

### DIFF
--- a/packages/chat-core/rollup.config.ts
+++ b/packages/chat-core/rollup.config.ts
@@ -1,8 +1,12 @@
 import rollupConfig from "rollup-config-nlx";
-import pkg from "./package.json" assert { type: "json" };
 
 export default rollupConfig({
-  pkg: pkg,
+  pkg: {
+    // This fields are copied over directly from package.json because importing it here was not working anymore in node@22
+    main: "lib/index.cjs",
+    module: "lib/index.esm.js",
+    browser: "lib/index.umd.js",
+  },
   name: "nlxai.chatCore",
   externalDeps: ["isomorphic-fetch", "reconnecting-websocket", "uuid", "ramda"],
   input: "src/index.ts",

--- a/packages/chat-preact/rollup.config.ts
+++ b/packages/chat-preact/rollup.config.ts
@@ -1,8 +1,11 @@
 import rollupConfig from "rollup-config-nlx";
-import pkg from "./package.json" assert { type: "json" };
 
 export default rollupConfig({
-  pkg: pkg,
+  pkg: {
+    // This fields are copied over directly from package.json because importing it here was not working anymore in node@22
+    main: "lib/index.cjs",
+    module: "lib/index.esm.js",
+  },
   externalDeps: ["preact/hooks", "ramda", "@nlxai/chat-core"],
   input: "src/index.ts",
 });

--- a/packages/chat-react/rollup.config.ts
+++ b/packages/chat-react/rollup.config.ts
@@ -1,8 +1,11 @@
 import rollupConfig from "rollup-config-nlx";
-import pkg from "./package.json" assert { type: "json" };
 
 export default rollupConfig({
-  pkg: pkg,
+  pkg: {
+    // This fields are copied over directly from package.json because importing it here was not working anymore in node@22
+    main: "lib/index.cjs",
+    module: "lib/index.esm.js",
+  },
   externalDeps: ["preact/hooks", "ramda", "@nlxai/chat-core"],
   input: "src/index.ts",
 });

--- a/packages/chat-widget/rollup.config.ts
+++ b/packages/chat-widget/rollup.config.ts
@@ -1,8 +1,12 @@
 import rollupConfig from "rollup-config-nlx";
-import pkg from "./package.json" assert { type: "json" };
 
 export default rollupConfig({
-  pkg: pkg,
+  pkg: {
+    // This fields are copied over directly from package.json because importing it here was not working anymore in node@22
+    main: "lib/index.cjs",
+    module: "lib/index.esm.js",
+    browser: "lib/index.umd.js",
+  },
   name: "nlxai.chatWidget",
   externalDeps: [
     "react/jsx-runtime",

--- a/packages/touchpoint-ui/src/components/Messages.tsx
+++ b/packages/touchpoint-ui/src/components/Messages.tsx
@@ -113,7 +113,6 @@ export const Messages: FC<MessagesProps> = ({
 
   useEffect(() => {
     if (!isWaiting) {
-      // TODO: the smooth scrolling consistently scrolls from the top of the conversation, looks like the scroll position is lost
       setTimeout(() => {
         lastBotMessageRef.current?.scrollIntoView({ behavior: "smooth" });
       });
@@ -187,7 +186,7 @@ export const Messages: FC<MessagesProps> = ({
                   return (
                     <div key={messageIndex} className="text-base">
                       <div
-                        className="pr-10"
+                        className="pr-10 space-y-6"
                         dangerouslySetInnerHTML={{
                           __html: marked(message.text),
                         }}

--- a/packages/voice-plus-core/rollup.config.ts
+++ b/packages/voice-plus-core/rollup.config.ts
@@ -1,8 +1,12 @@
 import rollupConfig from "rollup-config-nlx";
-import pkg from "./package.json" assert { type: "json" };
 
 export default rollupConfig({
-  pkg: pkg,
+  pkg: {
+    // This fields are copied over directly from package.json because importing it here was not working anymore in node@22
+    main: "lib/index.cjs",
+    module: "lib/index.esm.js",
+    browser: "lib/index.umd.js",
+  },
   name: "nlxai.voicePlusCore",
   externalDeps: ["isomorphic-fetch"],
   input: "src/index.ts",

--- a/packages/voice-plus-web/rollup.config.ts
+++ b/packages/voice-plus-web/rollup.config.ts
@@ -1,9 +1,13 @@
 import rollupConfig from "rollup-config-nlx";
-import pkg from "./package.json" assert { type: "json" };
 import css from "rollup-plugin-import-css";
 
 export default rollupConfig({
-  pkg: pkg,
+  pkg: {
+    // This fields are copied over directly from package.json because importing it here was not working anymore in node@22
+    main: "lib/index.cjs",
+    module: "lib/index.esm.js",
+    browser: "lib/index.umd.js",
+  },
   name: "nlxai.voicePlusWeb",
   externalDeps: [
     "@nlxai/voice-plus-core",


### PR DESCRIPTION
Attempt to fix the following build issue:

```
❯ npm run build                                                            

> @nlxai/chat-core@1.0.5-alpha.2 build         
> rm -rf lib && rollup -c --configPlugin typescript                    
                                                                           
[!] SyntaxError: Unexpected identifier 'assert'                            
    at compileSourceTextModule (node:internal/modules/esm/utils:338:16) 
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:102:18)
    at ModuleLoader.#translate (node:internal/modules/esm/loader:468:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:515:27)
    at ModuleJob._link (node:internal/modules/esm/module_job:115:19)
```