### PR TITLE
Fix touchpoint paragraph spacing

### DIFF
--- a/packages/touchpoint-ui/src/components/Messages.tsx
+++ b/packages/touchpoint-ui/src/components/Messages.tsx
@@ -187,7 +187,7 @@ export const Messages: FC<MessagesProps> = ({
                   return (
                     <div key={messageIndex} className="text-base">
                       <div
-                        className="pr-10"
+                        className="pr-10 space-y-6"
                         dangerouslySetInnerHTML={{
                           __html: marked(message.text),
                         }}


### PR DESCRIPTION
Make sure there's spacing between multiple paragraphs:
 
<img width="1273" alt="Screenshot 2025-04-21 at 22 32 26" src="https://github.com/user-attachments/assets/b4a13bcb-dffd-4be8-a9d5-6be6689bf473" />
