### PR TITLE
Stop sending welcome intent in voice

### DIFF
--- a/packages/touchpoint-ui/src/App.tsx
+++ b/packages/touchpoint-ui/src/App.tsx
@@ -246,7 +246,8 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
           }}
           reset={() => {
             handler.reset({ clearResponses: true });
-            handler.sendWelcomeIntent();
+            props.initializeConversation(handler);
+
             setVoiceActive(false);
           }}
         />

--- a/packages/touchpoint-ui/src/index.tsx
+++ b/packages/touchpoint-ui/src/index.tsx
@@ -142,7 +142,8 @@ class NlxTouchpointElement extends HTMLElement {
             initializeConversation={
               this.#touchpointConfiguration.initializeConversation ??
               ((handler) => {
-                handler.sendWelcomeIntent();
+                if (this.#touchpointConfiguration?.input === "text")
+                  handler.sendWelcomeIntent();
               })
             }
             onClose={this.onClose}


### PR DESCRIPTION
Also fixes the issue where if you customized your conversation initialization script, it wouldn't be used on reset.