### PR TITLE
Adds API doc explaining the React export

### DIFF
--- a/packages/touchpoint-ui/src/index.tsx
+++ b/packages/touchpoint-ui/src/index.tsx
@@ -21,6 +21,16 @@ import { createElement, type FC } from "react";
 import type { TouchpointConfiguration } from "./types";
 import { equals } from "ramda";
 
+/**
+ * If you wish to build custom modalities using JSX, you will want to
+ *
+ * ```javascript
+ * import { React } from "@nlx/touchpoint-ui";
+ * ```
+ *
+ * instead of importing from "react" directly. This ensures that the custom modalities will
+ * be running in the same React context as the Touchpoint UI using the correct version of React.
+ */
 export { default as React } from "react";
 
 // Create a htm instance where components can be used


### PR DESCRIPTION
This is something that others might find confusing so I added a quick API doc explaining how if you want JSX to work, you need to import React from our package rather than the "react" package.

I'd imagine this is something that you will want to incorporate into the guides somewhere, but I leave that up to you @dtolb .