### PR TITLE
Improve modality type

### DIFF
--- a/packages/chat-widget/src/index.tsx
+++ b/packages/chat-widget/src/index.tsx
@@ -245,7 +245,13 @@ const MessageGroups: FC<{
                   );
                   return null;
                 }
-                return <Component key={key} data={value} />;
+                return (
+                  <Component
+                    key={key}
+                    data={value}
+                    conversationHandler={props.chat.conversationHandler}
+                  />
+                );
               },
             )}
           </C.MessageGroup>

--- a/packages/chat-widget/src/props.ts
+++ b/packages/chat-widget/src/props.ts
@@ -48,7 +48,7 @@ export type StorageType = "localStorage" | "sessionStorage";
  * Custom Modalities allow rendering of rich components from nodes.
  * See: https://docs.studio.nlx.ai/build/resources/modalities
  */
-export type CustomModalityComponent<T = any> = ComponentType<{
+export type CustomModalityComponent<T = unknown> = ComponentType<{
   /**
    * The name of the Modality as defined in Dialog Studio settings.
    */

--- a/packages/chat-widget/src/props.ts
+++ b/packages/chat-widget/src/props.ts
@@ -1,4 +1,4 @@
-import { type FC } from "react";
+import { type ComponentType } from "react";
 import { type Config, type ConversationHandler } from "@nlxai/chat-core";
 import { type Theme } from "./theme";
 
@@ -48,7 +48,7 @@ export type StorageType = "localStorage" | "sessionStorage";
  * Custom Modalities allow rendering of rich components from nodes.
  * See: https://docs.studio.nlx.ai/build/resources/modalities
  */
-export type CustomModalityComponent = FC<{
+export type CustomModalityComponent<T = any> = ComponentType<{
   /**
    * The name of the Modality as defined in Dialog Studio settings.
    */
@@ -56,7 +56,12 @@ export type CustomModalityComponent = FC<{
   /**
    * The payload of the Custom Modality. The schema is defined in Dialog Studio settings.
    */
-  data: any;
+  data: T;
+
+  /**
+   * The conversation handler to use for sending messages and handling the conversation.
+   */
+  conversationHandler: ConversationHandler;
 }>;
 
 /**


### PR DESCRIPTION
The type variable is useless to us, but will allow users to strictly type their own components. So as a user I can now do:

```typescript 

import { type CustomModalityComponent } from "@nlxai/touchpoint-ui";

export type MyModality = {
  foo: string;
  bar: number[];
};

export const MyModalityHandler : CustomModalityComponent<MyModality> = ({data, conversationHandler}) => {
   return <div>{data.fo // <-- foo will be autocompleted here
}
```

But the new type will also support class based components (because why not? we're selling to enterprise after all).

Also before we didn't show the `conversationHandler` in the type.