### PR TITLE
Very Rough pass at bidi v+ in snippet

### DIFF
--- a/packages/website/src/snippets.ts
+++ b/packages/website/src/snippets.ts
@@ -95,7 +95,105 @@ const MuseumExhibitDetails = ({ data, conversationHandler }) => {
 };
 `;
 
-export type TemplateComponents = "noComponents" | "museumComponents";
+const bidirectionalVoicePlus = (
+  config: Config,
+): string => `import { analyzePageForms } from "https://unpkg.com/@nlxai/touchpoint-ui@1.1.0/lib/index.js?module";
+
+const touchpoint = await create({
+  config: {
+    applicationUrl: "${defaultTo(config.applicationUrl, "REPLACE_WITH_APPLICATION_URL")}",
+    headers: {
+      "nlx-api-key": "${defaultTo(
+        config.headers?.["nlx-api-key"],
+        "REPLACE_WITH_API_KEY",
+      )}"
+    },
+    bidirectional: true,
+    languageCode: "${config.languageCode}",
+    userId: "${defaultTo(config.userId, "REPLACE_WITH_USER_ID")}"
+
+  },
+  input: "voiceMini",
+});
+
+const pageForms = analyzePageForms();
+
+const handleNavigationCommand = (action, destination) => {
+  switch (action) {
+    case "page_next":
+      // Use browser's forward navigation
+      window.history.forward();
+      break;
+    case "page_previous":
+      // Use browser's back navigation
+      window.history.back();
+      break;
+    case "page_custom":
+      // Navigate to specific page using destination field
+      if (destination) {
+        window.location.href = destination;
+      }
+      break;
+    default:
+      console.log("Unknown navigation action:", action);
+  }
+};
+
+const handleInputCommand = (fields = []) => {
+  fields.forEach((field) => {
+    if (!field?.id) {
+      return;
+    }
+    if (pageForms.formElements[field.id]) {
+      const element = pageForms.formElements[field.id];
+      element.value = field.value ?? "";
+    } else {
+      console.warn(\`Form element with id \${field.id} not found\`);
+    }
+  });
+};
+
+const handleCustomCommand = (action, payload) => {
+  console.log("custom command:", action, payload);
+};
+
+const handleVoicePlusCommand = (command) => {
+  const { classification, action, destination, payload } = command;
+
+  switch (classification) {
+    case "navigation":
+      handleNavigationCommand(action, destination);
+      break;
+    case "input":
+      handleInputCommand(command?.fields);
+      break;
+    case "custom":
+      handleCustomCommand(action, payload);
+      break;
+    default:
+      console.log("Unknown command:", classification);
+  }
+};
+
+touchpoint.conversationHandler.sendContext({
+  "nlx:vpContext": {
+    url: window.location.href,
+    fields: pageForms.context,
+  },
+});
+
+touchpoint.conversationHandler.addEventListener(
+  "voicePlusCommand",
+  (command) => {
+    handleVoicePlusCommand(command);
+  },
+);
+`;
+
+export type TemplateComponents =
+  | "noComponents"
+  | "museumComponents"
+  | "bidirectionalVoicePlus";
 
 export const touchpointUiSetupSnippet = ({
   config,
@@ -114,6 +212,10 @@ export const touchpointUiSetupSnippet = ({
   colorMode: "light" | "dark";
   templateComponents?: TemplateComponents;
 }): string => {
+  if (templateComponents === "bidirectionalVoicePlus") {
+    return bidirectionalVoicePlus(config);
+  }
+
   return `${templateComponents === "museumComponents" ? `${museumComponents}\n\n` : ""}create({
   config: {
     applicationUrl: "${defaultTo(config.applicationUrl, "REPLACE_WITH_APPLICATION_URL")}",


### PR DESCRIPTION
Incredibly rough cut at adding BiDi V+ setup snippet from onboarding to dev docs. 

Follow same user-experience: select the template from the "Try it live" and the snippet contains the copypasta code for user. 

Open Questions
* templateComponents maybe not the best name/param for such a bigger snippet change
* try it live bidi v+ with user snippet maybe doesn't make sense for this page... We'd basically be V+ driver on docs page.. Should we remove try-it-live for this scenario
* Given the number of config and other options to enable BiDi V+  I just created a net-new snippet. Probably a better way to solve.

PR only meant to start conversation 