### PR TITLE
Improve API reference docs styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5805,6 +5805,16 @@
         }
       ]
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -5833,6 +5843,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -6930,6 +6946,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.3.tgz",
+      "integrity": "sha512-gJMigczVZqYAk0hPVzx/M4Hm1D9QOtqkdQk9005TNzDIUGzo5cnHEDiKUT7jGPximL/oYb+LIitcHFQ4aKupxg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7259,6 +7291,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dlv": {
@@ -9508,6 +9553,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
@@ -9551,6 +9609,43 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -14451,6 +14546,18 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nx": {
       "version": "16.10.0",
       "resolved": "https://registry.npmjs.org/nx/-/nx-16.10.0.tgz",
@@ -16812,6 +16919,64 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-sectionize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/remark-sectionize/-/remark-sectionize-2.1.0.tgz",
+      "integrity": "sha512-R/pHt1RLYrEqrbwOVXx8HnvvwOg+mxg8pE4kIWpIYE3/CuZhU8/PAx/0y1BbHWUA0jmTLTeWpUlDrS/B0pyd0g==",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-find-after": "^4.0.1",
+        "unist-util-visit": "^4.1.2"
+      }
+    },
+    "node_modules/remark-sectionize/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/remark-sectionize/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-sectionize/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-sectionize/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -19342,6 +19507,77 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/unist-util-filter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
+      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      }
+    },
+    "node_modules/unist-util-filter/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-filter/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
+      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-find-after/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
@@ -19364,6 +19600,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-remove-position": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
@@ -19371,6 +19622,33 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -19393,6 +19671,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -21343,6 +21622,7 @@
         "@react-hookz/web": "^23.1.0",
         "clsx": "^2.1.1",
         "fuse.js": "^7.0.0",
+        "hast-util-select": "^6.0.4",
         "htm": "^3.1.1",
         "ramda": "^0.29.1",
         "react": "^18.2.0",
@@ -21352,8 +21632,13 @@
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.0",
+        "remark-sectionize": "^2.1.0",
         "tinycolor2": "^1.4.1",
-        "type-fest": "^4.15.0"
+        "type-fest": "^4.15.0",
+        "unist-util-filter": "^5.0.1",
+        "unist-util-find-after": "^4.0.1",
+        "unist-util-remove": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5554,6 +5554,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "node_modules/attach-ware": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
+      "integrity": "sha512-OpavlXWZkyE7m28fpCWF/RmxCukC1edukJp9IKjEpZs/O11H3896DkLpK7lMiL8ZDx2yxo9FrZQaeHkyJGcIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "unherit": "^1.0.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -5774,7 +5783,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6125,6 +6133,35 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7442,6 +7479,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -7539,6 +7590,27 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/ent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
+      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "punycode": "^1.4.1",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ent/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "3.0.1",
@@ -7647,12 +7719,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7690,9 +7760,10 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -7803,6 +7874,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -9108,15 +9185,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9162,6 +9245,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -9375,11 +9471,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9465,9 +9562,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -9504,6 +9602,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/hast/-/hast-0.0.2.tgz",
+      "integrity": "sha512-1MrzC9MtAYhzLix2w++pGEtRyCm6N1fcxCjx+1xJo/92fNDRFemFaum18XWd8No3f+FgT9lv6fKOC8LZRcxxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "bail": "^1.0.0",
+        "camelcase": "^1.2.1",
+        "ent": "^2.2.0",
+        "escape-html": "^1.0.3",
+        "htmlparser2": "^3.8.3",
+        "param-case": "^1.1.1",
+        "property-information": "^2.0.0",
+        "trim": "0.0.1",
+        "unified": "^2.1.0"
       }
     },
     "node_modules/hast-util-from-parse5": {
@@ -9715,6 +9830,117 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hast/node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hast/node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/hast/node_modules/dom-serializer/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hast/node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast/node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hast/node_modules/domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/hast/node_modules/domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/hast/node_modules/entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hast/node_modules/htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "node_modules/hast/node_modules/property-information": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-2.0.0.tgz",
+      "integrity": "sha512-8oVcjnCeqANq/exCzgse3D47GBmgOuI47vNya7xBIJhUXeh49AjZuXWw2gTh1UuN4rfwz5pEv2ZFzu45vBby5A==",
+      "license": "MIT"
+    },
+    "node_modules/hast/node_modules/unified": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
+      "integrity": "sha512-qa4nA26ms49OczPueTt7G46r89TOlwAJ4pEk2U4mwkV1wNhjttItF03SE/YnfkgWg14tzmAHXGhJp2GhDYwn1A==",
+      "license": "MIT",
+      "dependencies": {
+        "attach-ware": "^1.0.0",
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "unherit": "^1.0.4",
+        "vfile": "^1.0.0",
+        "ware": "^1.3.0"
+      }
+    },
+    "node_modules/hast/node_modules/vfile": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+      "integrity": "sha512-7Fz639rwERslMqQCuf1/0H4Tqe2q484Xl6X/jsKqrP7IjFcDODFURhv0GekMnImpbj9pTOojtqL7r39LJJkjGA==",
+      "license": "MIT"
     },
     "node_modules/hastscript": {
       "version": "6.0.0",
@@ -10612,12 +10838,15 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12197,6 +12426,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==",
+      "license": "MIT"
+    },
     "node_modules/lowlight": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -12339,6 +12574,15 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -15301,6 +15545,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/param-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
+      "integrity": "sha512-gksk6zeZQxwBm1AHsKh+XDFsTGf1LvdZSkkpSIkfDtzW+EQj/P2PBgNb3Cs0Y9Xxqmbciv2JZe3fWU6Xbher+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "sentence-case": "^1.1.2"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16553,7 +16806,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17427,13 +17679,14 @@
       ]
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17489,6 +17742,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sentence-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
+      "integrity": "sha512-laa/UDTPXsrQnoN/Kc8ZO7gTeEjMsuPiDgUCk9N0iINRZvqAMCTXjGl8+tD27op1eF/JHbdUlEUmovDh6AX7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^1.1.1"
       }
     },
     "node_modules/serialize-javascript": {
@@ -18063,7 +18325,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -18698,6 +18959,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
+      "deprecated": "Use String.prototype.trim() instead"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -19407,6 +19674,20 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
+    "node_modules/unherit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/unified": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
@@ -19507,43 +19788,11 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/unist-util-filter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
-      "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      }
-    },
-    "node_modules/unist-util-filter/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-filter/node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
+    "node_modules/unist": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/unist/-/unist-0.0.1.tgz",
+      "integrity": "sha512-bnzuF8b6d47WubA4a5yLqFbuZz/v/NS6eRwUIdOaDmsqzwTlyv8yS1g3M7ISdtBQrigPD3qKK87Cu7zhEfCF3A==",
+      "deprecated": "Use @types/unist instead"
     },
     "node_modules/unist-util-find-after": {
       "version": "4.0.1",
@@ -19841,8 +20090,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -20492,6 +20740,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/ware": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+      "integrity": "sha512-Y2HUDMktriUm+SR2gZWxlrszcgtXExlhQYZ8QJNYbl22jum00KIUcHJ/h/sdAXhWTJcbSkiMYN9Z2tWbWYSrrw==",
+      "license": "MIT",
+      "dependencies": {
+        "wrap-fn": "^0.1.0"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -20683,6 +20940,21 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrap-fn": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+      "integrity": "sha512-xDLdGx0M8JQw9QDAC9s5NUxtg9MI09F6Vbxa2LYoSoCvzJnx2n81YMIfykmXEGsUvuLaxnblJTzhSOjUOX37ag==",
+      "license": "MIT",
+      "dependencies": {
+        "co": "3.1.0"
+      }
+    },
+    "node_modules/wrap-fn/node_modules/co": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+      "integrity": "sha512-CQsjCRiNObI8AtTsNIBDRMQ4oMR83CzEswHYahClvul7gKk+lDQiOKv+5qh7LQWf5sh6jkZNispz/QlsZxyNgA==",
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -21295,6 +21567,7 @@
         "@react-hookz/web": "^25.0.1",
         "@react-input/mask": "^2.0.4",
         "clsx": "^2.1.1",
+        "hast": "^0.0.2",
         "htm": "^3.1.1",
         "livekit-client": "^2.9.9",
         "marked": "^15.0.4",
@@ -21302,7 +21575,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-indiana-drag-scroll": "^2.2.0",
-        "react-textarea-autosize": "^8.5.6"
+        "react-textarea-autosize": "^8.5.6",
+        "unist": "^0.0.1"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "^6.0.2",
@@ -21635,7 +21909,6 @@
         "remark-sectionize": "^2.1.0",
         "tinycolor2": "^1.4.1",
         "type-fest": "^4.15.0",
-        "unist-util-filter": "^5.0.1",
         "unist-util-find-after": "^4.0.1",
         "unist-util-remove": "^4.0.0",
         "unist-util-visit": "^5.0.0"

--- a/packages/touchpoint-ui/package.json
+++ b/packages/touchpoint-ui/package.json
@@ -28,6 +28,7 @@
     "@react-hookz/web": "^25.0.1",
     "@react-input/mask": "^2.0.4",
     "clsx": "^2.1.1",
+    "hast": "^0.0.2",
     "htm": "^3.1.1",
     "livekit-client": "^2.9.9",
     "marked": "^15.0.4",
@@ -35,7 +36,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-indiana-drag-scroll": "^2.2.0",
-    "react-textarea-autosize": "^8.5.6"
+    "react-textarea-autosize": "^8.5.6",
+    "unist": "^0.0.1"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^6.0.2",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -28,6 +28,7 @@
     "@react-hookz/web": "^23.1.0",
     "clsx": "^2.1.1",
     "fuse.js": "^7.0.0",
+    "hast-util-select": "^6.0.4",
     "htm": "^3.1.1",
     "ramda": "^0.29.1",
     "react": "^18.2.0",
@@ -37,8 +38,12 @@
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0",
+    "remark-sectionize": "^2.1.0",
     "tinycolor2": "^1.4.1",
-    "type-fest": "^4.15.0"
+    "type-fest": "^4.15.0",
+    "unist-util-find-after": "^4.0.1",
+    "unist-util-remove": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.3",

--- a/packages/website/src/components/PageContent.tsx
+++ b/packages/website/src/components/PageContent.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import Markdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import remarkGfm from "remark-gfm";
+import remarkSectionize from "remark-sectionize";
 import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import touchpointUiPackageJson from "@nlxai/touchpoint-ui/package.json";
@@ -12,6 +13,11 @@ import { type SnippetEnv } from "../types";
 import { indentBy } from "../snippets";
 import { Toggle } from "./Toggle";
 import { CheckIcon, ContentCopyIcon } from "./Icons";
+import { CONTINUE, SKIP, visit } from "unist-util-visit";
+import { findAfter } from "unist-util-find-after";
+import { selectAll } from "hast-util-select";
+import { filter } from "unist-util-filter";
+import { remove } from "unist-util-remove";
 
 const { version } = touchpointUiPackageJson;
 
@@ -174,6 +180,176 @@ export const PageContent: FC<{ md: string; className?: string }> = ({
           code({ children, className }) {
             return <Code className={className}>{children}</Code>;
           },
+        }}
+      >
+        {md}
+      </Markdown>
+    </Prose>
+  );
+};
+
+const rehypePostprocessDocs = () => {
+  const githubLink = (src) => ({
+    type: "element",
+    tagName: "a",
+    properties: {
+      href: src,
+      className: [
+        "absolute",
+        "top-6",
+        "right-4",
+        "text-primary-60",
+        "hover:text-primary-80",
+      ],
+      target: "_blank",
+      rel: "noopener noreferrer",
+    },
+    children: [
+      {
+        type: "element",
+        tagName: "svg",
+        properties: {
+          xmlns: "http://www.w3.org/2000/svg",
+          viewBox: "0 0 16 16",
+          class: "w-4 h-4",
+        },
+        children: [
+          {
+            type: "element",
+            tagName: "path",
+            properties: {
+              fill: "currentColor",
+              d: "M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z",
+            },
+            children: [],
+          },
+        ],
+      },
+    ],
+  });
+
+  const toDepth = (node) => {
+    if (node.tagName === "h1") return 1;
+    if (node.tagName === "h2") return 2;
+    if (node.tagName === "h3") return 3;
+    if (node.tagName === "h4") return 4;
+    if (node.tagName === "h5") return 5;
+    if (node.tagName === "h6") return 6;
+
+    return 0;
+  };
+  function sectionize(node, index, parent) {
+    const start = node;
+    const startIndex = index;
+    const depth = start.depth;
+
+    const isEnd = (n) =>
+      n.type === "element" &&
+      ["h1", "h2", "h3", "h4", "h5", "h6"].includes(n.tagName) &&
+      toDepth(n) <= toDepth(node);
+    const end = findAfter(parent, start, isEnd);
+    const endIndex = parent.children.indexOf(end);
+
+    const between = parent.children.slice(
+      startIndex,
+      endIndex > 0 ? endIndex : undefined,
+    );
+
+    const section = {
+      type: "element",
+      tagName: "section",
+      children: between,
+      properties: {
+        class: [
+          "relative",
+          "bg-primary-5",
+          "px-4",
+          "py-1",
+          "mb-4",
+          "rounded-xl",
+        ],
+      },
+    };
+    // console.log(
+    //   `Sectionizing ${node.tagName} at index ${startIndex} to ${endIndex}, looking for "h${toDepth(node) + 1}"`,
+    // );
+
+    let definedIn = selectAll(`h${toDepth(node) + 1}`, section).find(
+      (n) => n.children[0].value === "Defined in",
+    );
+
+    if (definedIn != null) {
+      // console.log(section.children);
+      section.children[2] = {
+        type: "element",
+        tagName: "pre",
+        properties: {
+          class: ["whitespace-pre-wrap", "!font-mono"],
+        },
+        children: section.children[2].children,
+      };
+
+      const definedIndex = section.children.indexOf(definedIn);
+
+      section.children.splice(
+        definedIndex,
+        3,
+        githubLink(
+          section.children[definedIndex + 2].children[0].properties.href,
+        ),
+      );
+      parent.children.splice(startIndex, section.children.length, section);
+      return SKIP;
+    } else {
+      // console.log(`Not found`, node);
+      return CONTINUE;
+    }
+  }
+  return (tree: any) => {
+    visit(
+      tree,
+      (node) =>
+        node.type === "element" && ["h2", "h3", "h4"].includes(node.tagName),
+      sectionize,
+    );
+    remove(tree, (node) => node.tagName === "hr");
+  };
+};
+
+export const ApiDocContent: FC<{ md: string; className?: string }> = ({
+  md,
+  className,
+}) => {
+  return (
+    <Prose className={className}>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeSlug, rehypePostprocessDocs]}
+        components={{
+          a(props) {
+            // `concat-md` output contains markup such as <a name="interfacespropsmd"></a> as anchor targets. However, react types don't expect the (basically deprecated) `name` attribute, hence the `as unknown as any` hack.
+            // markdown package typings expect it not to.
+            const name: string | undefined = (props as unknown as any).name;
+            // eslint-disable-next-line react/prop-types
+            if (props.href == null && name != null) {
+              // redefine `name` as `id` as suggested in the MDN for anchor targets.
+              return <a id={name}>{props.children}</a>;
+            }
+            // TODO: when using a react-router redirect, scroll to heading ID if available
+
+            // eslint-disable-next-line react/prop-types
+            return (
+              <Link className={props.className} to={props.href ?? ""}>
+                {props.children}
+              </Link>
+            );
+          },
+          // pre({ children, className }) {
+          //   return <Code className={className}>{children}</Code>;
+          // },
+          // code({ children, className }) {
+          //   return <Code className={className}>{children}</Code>;
+          // },
         }}
       >
         {md}

--- a/packages/website/src/content/02-10-touchpoint-ui-api-reference.tsx
+++ b/packages/website/src/content/02-10-touchpoint-ui-api-reference.tsx
@@ -1,5 +1,5 @@
 import { type FC } from "react";
-import { PageContent } from "../components/PageContent";
+import { ApiDocContent } from "../components/PageContent";
 import content from "./touchpoint-ui-api-reference.md?raw";
 
 export const navGroup: string = "Touchpoint Setup";
@@ -7,5 +7,5 @@ export const navGroup: string = "Touchpoint Setup";
 export const title: string = "API reference";
 
 export const Content: FC<unknown> = () => {
-  return <PageContent md={content} />;
+  return <ApiDocContent md={content} />;
 };

--- a/packages/website/src/content/headless-api-reference.md
+++ b/packages/website/src/content/headless-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/chat-core
@@ -8,6 +9,7 @@
 - [BotResponse](#interfacesbotresponsemd)
 - [BotResponsePayload](#interfacesbotresponsepayloadmd)
 - [BotResponseMetadata](#interfacesbotresponsemetadatamd)
+- [KnowledgeBaseResponseSource](#interfacesknowledgebaseresponsesourcemd)
 - [BotMessageMetadata](#interfacesbotmessagemetadatamd)
 - [BotMessage](#interfacesbotmessagemd)
 - [UploadUrl](#interfacesuploadurlmd)
@@ -16,8 +18,8 @@
 - [FailureMessage](#interfacesfailuremessagemd)
 - [Config](#interfacesconfigmd)
 - [StructuredRequest](#interfacesstructuredrequestmd)
-- [BotRequest](#interfacesbotrequestmd)
-- [LiveKitCredentials](#interfaceslivekitcredentialsmd)
+- [ApplicationRequest](#interfacesapplicationrequestmd)
+- [VoiceCredentials](#interfacesvoicecredentialsmd)
 - [ChoiceRequestMetadata](#interfaceschoicerequestmetadatamd)
 - [VoicePlusMessage](#interfacesvoiceplusmessagemd)
 - [EventHandlers](#interfaceseventhandlersmd)
@@ -33,9 +35,9 @@
 
 #### Defined in
 
-[index.ts:13](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L13)
+[index.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L18)
 
----
+___
 
 ### SlotsRecord
 
@@ -52,9 +54,9 @@ A `SlotsRecord` is equivalent to an array of [SlotValue](#interfacesslotvaluemd)
 
 #### Defined in
 
-[index.ts:42](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L42)
+[index.ts:47](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L47)
 
----
+___
 
 ### SlotsRecordOrArray
 
@@ -66,21 +68,33 @@ Supports either a [SlotsRecord](#slotsrecord) or an array of [SlotValue](#interf
 
 #### Defined in
 
-[index.ts:49](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L49)
+[index.ts:54](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L54)
 
----
+___
+
+### ModalityPayloads
+
+Ƭ **ModalityPayloads**: `Record`\<`string`, `any`\>
+
+Payloads for modalities as a key-value pair by modality name
+
+#### Defined in
+
+[index.ts:117](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L117)
+
+___
 
 ### UserResponsePayload
 
-Ƭ **UserResponsePayload**: \{ `type`: `"text"` ; `text`: `string` ; `context?`: [`Context`](#context) } \| \{ `type`: `"choice"` ; `choiceId`: `string` ; `context?`: [`Context`](#context) } \| \{ `type`: `"structured"` ; `context?`: [`Context`](#context) } & [`StructuredRequest`](#interfacesstructuredrequestmd)
+Ƭ **UserResponsePayload**: \{ `type`: ``"text"`` ; `text`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"choice"`` ; `choiceId`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"structured"`` ; `context?`: [`Context`](#context)  } & [`StructuredRequest`](#interfacesstructuredrequestmd)
 
 The payload of the user response
 
 #### Defined in
 
-[index.ts:242](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L242)
+[index.ts:282](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L282)
 
----
+___
 
 ### Response
 
@@ -90,9 +104,9 @@ A response from the application or the user.
 
 #### Defined in
 
-[index.ts:311](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L311)
+[index.ts:351](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L351)
 
----
+___
 
 ### Time
 
@@ -102,21 +116,37 @@ The time value in milliseconds since midnight, January 1, 1970 UTC.
 
 #### Defined in
 
-[index.ts:316](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L316)
+[index.ts:356](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L356)
 
----
+___
 
 ### NormalizedStructuredRequest
 
-Ƭ **NormalizedStructuredRequest**: [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[] }
+Ƭ **NormalizedStructuredRequest**: [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[]  }
 
 Normalized structured request with a single way to represent slots
 
 #### Defined in
 
-[index.ts:455](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L455)
+[index.ts:505](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L505)
 
----
+___
+
+### BotRequest
+
+Ƭ **BotRequest**: [`ApplicationRequest`](#interfacesapplicationrequestmd)
+
+Legacy name for application request
+
+**`Deprecated`**
+
+use [ApplicationRequest](#interfacesapplicationrequestmd)
+
+#### Defined in
+
+[index.ts:557](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L557)
+
+___
 
 ### LanguageCode
 
@@ -126,26 +156,26 @@ Language code named for clarity, may restrict it to a finite list
 
 #### Defined in
 
-[index.ts:555](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L555)
+[index.ts:611](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L611)
 
----
+___
 
-### BotRequestOverride
+### RequestOverride
 
-Ƭ **BotRequestOverride**: (`botRequest`: [`BotRequest`](#interfacesbotrequestmd), `appendBotResponse`: (`res`: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)) => `void`) => `void`
+Ƭ **RequestOverride**: (`botRequest`: [`BotRequest`](#botrequest), `appendResponse`: (`res`: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)) => `void`) => `void`
 
 Instead of sending a request to the application, handle it in a custom fashion
 
 #### Type declaration
 
-▸ (`botRequest`, `appendBotResponse`): `void`
+▸ (`botRequest`, `appendResponse`): `void`
 
 ##### Parameters
 
-| Name                | Type                                                                       | Description                                                        |
-| :------------------ | :------------------------------------------------------------------------- | :----------------------------------------------------------------- |
-| `botRequest`        | [`BotRequest`](#interfacesbotrequestmd)                                    | The [BotRequest](#interfacesbotrequestmd) that is being overridden |
-| `appendBotResponse` | (`res`: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)) => `void` | -                                                                  |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `botRequest` | [`BotRequest`](#botrequest) | The [BotRequest](#botrequest) that is being overridden |
+| `appendResponse` | (`res`: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)) => `void` | A method to append the [BotResponsePayload](#interfacesbotresponsepayloadmd) to the message history |
 
 ##### Returns
 
@@ -153,9 +183,25 @@ Instead of sending a request to the application, handle it in a custom fashion
 
 #### Defined in
 
-[index.ts:562](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L562)
+[index.ts:618](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L618)
 
----
+___
+
+### BotRequestOverride
+
+Ƭ **BotRequestOverride**: [`RequestOverride`](#requestoverride)
+
+Legacy name for bot request override
+
+**`Deprecated`**
+
+use [RequestOverride](#requestoverride) instead
+
+#### Defined in
+
+[index.ts:627](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L627)
+
+___
 
 ### VoicePlusContext
 
@@ -165,21 +211,21 @@ Voice+ context, type to be defined
 
 #### Defined in
 
-[index.ts:570](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L570)
+[index.ts:632](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L632)
 
----
+___
 
 ### ConversationHandlerEvent
 
-Ƭ **ConversationHandlerEvent**: `"voicePlusCommand"`
+Ƭ **ConversationHandlerEvent**: ``"voicePlusCommand"``
 
 Handler events
 
 #### Defined in
 
-[index.ts:585](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L585)
+[index.ts:647](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L647)
 
----
+___
 
 ### Subscriber
 
@@ -193,10 +239,10 @@ The callback function for listening to all responses.
 
 ##### Parameters
 
-| Name           | Type                      |
-| :------------- | :------------------------ |
-| `response`     | [`Response`](#response)[] |
-| `newResponse?` | [`Response`](#response)   |
+| Name | Type |
+| :------ | :------ |
+| `response` | [`Response`](#response)[] |
+| `newResponse?` | [`Response`](#response) |
 
 ##### Returns
 
@@ -204,7 +250,19 @@ The callback function for listening to all responses.
 
 #### Defined in
 
-[index.ts:743](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L743)
+[index.ts:825](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L825)
+
+## Variables
+
+### version
+
+• `Const` **version**: `string` = `packageJson.version`
+
+Package version
+
+#### Defined in
+
+[index.ts:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L10)
 
 ## Functions
 
@@ -219,8 +277,8 @@ The order of configs doesn't matter.
 
 #### Parameters
 
-| Name      | Type                            |
-| :-------- | :------------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `config1` | [`Config`](#interfacesconfigmd) |
 | `config2` | [`Config`](#interfacesconfigmd) |
 
@@ -232,9 +290,9 @@ true if `createConversation` should be called again
 
 #### Defined in
 
-[index.ts:754](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L754)
+[index.ts:836](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L836)
 
----
+___
 
 ### isConfigValid
 
@@ -244,8 +302,8 @@ Check whether a configuration is value.
 
 #### Parameters
 
-| Name     | Type                            | Description        |
-| :------- | :------------------------------ | :----------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `config` | [`Config`](#interfacesconfigmd) | Chat configuration |
 
 #### Returns
@@ -256,9 +314,9 @@ isValid - Whether the configuration is valid
 
 #### Defined in
 
-[index.ts:781](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L781)
+[index.ts:891](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L891)
 
----
+___
 
 ### createConversation
 
@@ -268,8 +326,8 @@ Call this to create a conversation handler.
 
 #### Parameters
 
-| Name     | Type                            |
-| :------- | :------------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `config` | [`Config`](#interfacesconfigmd) |
 
 #### Returns
@@ -280,37 +338,37 @@ The [ConversationHandler](#interfacesconversationhandlermd) is a bundle of funct
 
 #### Defined in
 
-[index.ts:793](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L793)
+[index.ts:903](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L903)
 
----
+___
 
 ### getCurrentExpirationTimestamp
 
-▸ **getCurrentExpirationTimestamp**(`responses`): `null` \| `number`
+▸ **getCurrentExpirationTimestamp**(`responses`): ``null`` \| `number`
 
 Get current expiration timestamp from the current list of reponses
 
 #### Parameters
 
-| Name        | Type                      | Description                                                                           |
-| :---------- | :------------------------ | :------------------------------------------------------------------------------------ |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `responses` | [`Response`](#response)[] | the current list of user and bot responses (first argument in the subscribe callback) |
 
 #### Returns
 
-`null` \| `number`
+``null`` \| `number`
 
 an expiration timestamp in Unix Epoch (`new Date().getTime()`), or `null` if this is not known (typically occurs if the bot has not responded yet)
 
 #### Defined in
 
-[index.ts:1321](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L1321)
+[index.ts:1488](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L1488)
 
----
+___
 
 ### promisify
 
-▸ **promisify**\<`T`\>(`fn`, `convo`, `timeout?`): (`payload`: `T`) => `Promise`\<[`Response`](#response) \| `null`\>
+▸ **promisify**\<`T`\>(`fn`, `convo`, `timeout?`): (`payload`: `T`) => `Promise`\<[`Response`](#response) \| ``null``\>
 
 This package is intentionally designed with a subscription-based API as opposed to a promise-based one where each message corresponds to a single bot response, available asynchronously.
 
@@ -318,17 +376,17 @@ If you need a promise-based wrapper, you can use the `promisify` helper availabl
 
 #### Type parameters
 
-| Name | Description                                                                                   |
-| :--- | :-------------------------------------------------------------------------------------------- |
-| `T`  | the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context` |
+| Name | Description |
+| :------ | :------ |
+| `T` | the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context` |
 
 #### Parameters
 
-| Name      | Type                                                      | Default value | Description                                                                |
-| :-------- | :-------------------------------------------------------- | :------------ | :------------------------------------------------------------------------- |
-| `fn`      | (`payload`: `T`) => `void`                                | `undefined`   | the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.)     |
-| `convo`   | [`ConversationHandler`](#interfacesconversationhandlermd) | `undefined`   | the `ConversationHandler` (from [createConversation](#createconversation)) |
-| `timeout` | `number`                                                  | `10000`       | the timeout in milliseconds                                                |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `fn` | (`payload`: `T`) => `void` | `undefined` | the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.) |
+| `convo` | [`ConversationHandler`](#interfacesconversationhandlermd) | `undefined` | the `ConversationHandler` (from [createConversation](#createconversation)) |
+| `timeout` | `number` | `10000` | the timeout in milliseconds |
 
 #### Returns
 
@@ -336,17 +394,17 @@ If you need a promise-based wrapper, you can use the `promisify` helper availabl
 
 A promise-wrapped version of the function. The function, when called, returns a promise that resolves to the Conversation's next response.
 
-▸ (`payload`): `Promise`\<[`Response`](#response) \| `null`\>
+▸ (`payload`): `Promise`\<[`Response`](#response) \| ``null``\>
 
 ##### Parameters
 
-| Name      | Type |
-| :-------- | :--- |
-| `payload` | `T`  |
+| Name | Type |
+| :------ | :------ |
+| `payload` | `T` |
 
 ##### Returns
 
-`Promise`\<[`Response`](#response) \| `null`\>
+`Promise`\<[`Response`](#response) \| ``null``\>
 
 **`Example`**
 
@@ -364,11 +422,77 @@ sendTextWrapped("Hello").then((response) => {
 
 #### Defined in
 
-[index.ts:1358](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L1358)
+[index.ts:1525](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L1525)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
+
+<a name="interfacesapplicationrequestmd"></a>
+
+## Interface: ApplicationRequest
+
+The request data actually sent to the application, slightly different from [UserResponsePayload](#userresponsepayload), which includes some UI-specific information
+
+### Properties
+
+#### conversationId
+
+• `Optional` **conversationId**: `string`
+
+The current conversation ID
+
+##### Defined in
+
+[index.ts:519](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L519)
+
+___
+
+#### userId
+
+• `Optional` **userId**: `string`
+
+The current user ID
+
+##### Defined in
+
+[index.ts:523](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L523)
+
+___
+
+#### context
+
+• `Optional` **context**: [`Context`](#context)
+
+Request context, if applicable
+
+##### Defined in
+
+[index.ts:527](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L527)
+
+___
+
+#### request
+
+• **request**: `Object`
+
+Main request
+
+##### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `unstructured?` | \{ `text`: `string`  } | Unstructured request |
+| `unstructured.text` | `string` | Request body text |
+| `structured?` | [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[]  } | Structured request |
+
+##### Defined in
+
+[index.ts:531](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L531)
+
 
 <a name="interfacesbotmessagemd"></a>
 
@@ -386,9 +510,9 @@ A unique identifier for the message.
 
 ##### Defined in
 
-[index.ts:158](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L158)
+[index.ts:198](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L198)
 
----
+___
 
 #### nodeId
 
@@ -399,9 +523,9 @@ This is must be sent with a choice when the user is changing a previously sent c
 
 ##### Defined in
 
-[index.ts:163](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L163)
+[index.ts:203](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L203)
 
----
+___
 
 #### text
 
@@ -411,9 +535,9 @@ The body of the message. Show this to the user.
 
 ##### Defined in
 
-[index.ts:167](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L167)
+[index.ts:207](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L207)
 
----
+___
 
 #### choices
 
@@ -423,9 +547,9 @@ A selection of choices to show to the user. They may choose one of them.
 
 ##### Defined in
 
-[index.ts:171](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L171)
+[index.ts:211](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L211)
 
----
+___
 
 #### metadata
 
@@ -435,9 +559,9 @@ Metadata
 
 ##### Defined in
 
-[index.ts:175](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L175)
+[index.ts:215](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L215)
 
----
+___
 
 #### selectedChoiceId
 
@@ -448,7 +572,8 @@ This field is set locally and does not come from the application.
 
 ##### Defined in
 
-[index.ts:180](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L180)
+[index.ts:220](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L220)
+
 
 <a name="interfacesbotmessagemetadatamd"></a>
 
@@ -467,69 +592,8 @@ The message node's intent
 
 ##### Defined in
 
-[index.ts:148](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L148)
+[index.ts:188](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L188)
 
-<a name="interfacesbotrequestmd"></a>
-
-## Interface: BotRequest
-
-The request data actually sent to the application, slightly different from [UserResponsePayload](#userresponsepayload), which includes some UI-specific information
-
-### Properties
-
-#### conversationId
-
-• `Optional` **conversationId**: `string`
-
-The current conversation ID
-
-##### Defined in
-
-[index.ts:469](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L469)
-
----
-
-#### userId
-
-• `Optional` **userId**: `string`
-
-The current user ID
-
-##### Defined in
-
-[index.ts:473](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L473)
-
----
-
-#### context
-
-• `Optional` **context**: [`Context`](#context)
-
-Request context, if applicable
-
-##### Defined in
-
-[index.ts:477](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L477)
-
----
-
-#### request
-
-• **request**: `Object`
-
-Main request
-
-##### Type declaration
-
-| Name                | Type                                                                                                           | Description          |
-| :------------------ | :------------------------------------------------------------------------------------------------------------- | :------------------- |
-| `unstructured?`     | \{ `text`: `string` }                                                                                          | Unstructured request |
-| `unstructured.text` | `string`                                                                                                       | Request body text    |
-| `structured?`       | [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[] } | Structured request   |
-
-##### Defined in
-
-[index.ts:481](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L481)
 
 <a name="interfacesbotresponsemd"></a>
 
@@ -538,7 +602,6 @@ Main request
 A message from the application
 
 See also:
-
 - [UserResponse](#interfacesuserresponsemd)
 - [FailureMessage](#interfacesfailuremessagemd)
 - [Response](#response)
@@ -547,15 +610,15 @@ See also:
 
 #### type
 
-• **type**: `"bot"`
+• **type**: ``"bot"``
 
 The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
 
 ##### Defined in
 
-[index.ts:63](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L63)
+[index.ts:68](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L68)
 
----
+___
 
 #### receivedAt
 
@@ -565,9 +628,9 @@ When the response was received
 
 ##### Defined in
 
-[index.ts:67](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L67)
+[index.ts:72](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L72)
 
----
+___
 
 #### payload
 
@@ -577,7 +640,8 @@ The payload of the response
 
 ##### Defined in
 
-[index.ts:71](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L71)
+[index.ts:76](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L76)
+
 
 <a name="interfacesbotresponsemetadatamd"></a>
 
@@ -596,9 +660,9 @@ The conversation's intent
 
 ##### Defined in
 
-[index.ts:117](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L117)
+[index.ts:127](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L127)
 
----
+___
 
 #### escalation
 
@@ -608,9 +672,9 @@ Whether the current conversation has been marked as incomprehension.
 
 ##### Defined in
 
-[index.ts:121](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L121)
+[index.ts:131](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L131)
 
----
+___
 
 #### frustration
 
@@ -620,9 +684,9 @@ Whether the current conversation has been marked frustrated
 
 ##### Defined in
 
-[index.ts:125](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L125)
+[index.ts:135](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L135)
 
----
+___
 
 #### incomprehension
 
@@ -632,9 +696,9 @@ Whether the current conversation has been marked as incomprehension.
 
 ##### Defined in
 
-[index.ts:129](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L129)
+[index.ts:139](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L139)
 
----
+___
 
 #### uploadUrls
 
@@ -644,9 +708,9 @@ Upload URL's
 
 ##### Defined in
 
-[index.ts:133](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L133)
+[index.ts:143](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L143)
 
----
+___
 
 #### hasPendingDataRequest
 
@@ -656,7 +720,20 @@ Whether the client should poll for more application responses.
 
 ##### Defined in
 
-[index.ts:137](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L137)
+[index.ts:147](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L147)
+
+___
+
+#### sources
+
+• `Optional` **sources**: [`KnowledgeBaseResponseSource`](#interfacesknowledgebaseresponsesourcemd)[]
+
+Knowledge base sources
+
+##### Defined in
+
+[index.ts:151](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L151)
+
 
 <a name="interfacesbotresponsepayloadmd"></a>
 
@@ -674,9 +751,9 @@ If there isn't some interaction by this time, the conversation will expire.
 
 ##### Defined in
 
-[index.ts:81](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L81)
+[index.ts:86](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L86)
 
----
+___
 
 #### conversationId
 
@@ -686,9 +763,9 @@ The active conversation ID. If not set, a new conversation will be started.
 
 ##### Defined in
 
-[index.ts:85](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L85)
+[index.ts:90](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L90)
 
----
+___
 
 #### messages
 
@@ -698,9 +775,9 @@ Any messages from the bot.
 
 ##### Defined in
 
-[index.ts:89](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L89)
+[index.ts:94](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L94)
 
----
+___
 
 #### metadata
 
@@ -711,9 +788,9 @@ as well as whether the client should poll for more application responses.
 
 ##### Defined in
 
-[index.ts:94](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L94)
+[index.ts:99](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L99)
 
----
+___
 
 #### payload
 
@@ -723,21 +800,21 @@ If configured, the [node's payload.](#add-functionality)
 
 ##### Defined in
 
-[index.ts:98](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L98)
+[index.ts:103](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L103)
 
----
+___
 
 #### modalities
 
-• `Optional` **modalities**: `Record`\<`string`, `any`\>
+• `Optional` **modalities**: [`ModalityPayloads`](#modalitypayloads)
 
 If configured, the node's modalities and their payloads.
 
 ##### Defined in
 
-[index.ts:102](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L102)
+[index.ts:107](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L107)
 
----
+___
 
 #### context
 
@@ -747,7 +824,8 @@ If the node is set to send context, the whole context associated with the conver
 
 ##### Defined in
 
-[index.ts:106](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L106)
+[index.ts:111](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L111)
+
 
 <a name="interfaceschoicemd"></a>
 
@@ -765,9 +843,9 @@ A choices to show to the user.
 
 ##### Defined in
 
-[index.ts:204](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L204)
+[index.ts:244](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L244)
 
----
+___
 
 #### choiceText
 
@@ -777,9 +855,9 @@ The text of the choice
 
 ##### Defined in
 
-[index.ts:208](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L208)
+[index.ts:248](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L248)
 
----
+___
 
 #### choicePayload
 
@@ -789,7 +867,8 @@ An optional, schemaless payload for the choice.
 
 ##### Defined in
 
-[index.ts:212](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L212)
+[index.ts:252](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L252)
+
 
 <a name="interfaceschoicerequestmetadatamd"></a>
 
@@ -809,9 +888,9 @@ It is not sent to the application.
 
 ##### Defined in
 
-[index.ts:534](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L534)
+[index.ts:590](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L590)
 
----
+___
 
 #### messageIndex
 
@@ -823,9 +902,9 @@ It is not sent to the application.
 
 ##### Defined in
 
-[index.ts:540](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L540)
+[index.ts:596](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L596)
 
----
+___
 
 #### nodeId
 
@@ -836,9 +915,9 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 ##### Defined in
 
-[index.ts:545](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L545)
+[index.ts:601](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L601)
 
----
+___
 
 #### intentId
 
@@ -848,7 +927,8 @@ Intent ID, used for sending to the NLU to allow it to double-check
 
 ##### Defined in
 
-[index.ts:549](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L549)
+[index.ts:605](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L605)
+
 
 <a name="interfacesconfigmd"></a>
 
@@ -866,9 +946,9 @@ Fetch this from the application's Deployment page.
 
 ##### Defined in
 
-[index.ts:332](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L332)
+[index.ts:372](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L372)
 
----
+___
 
 #### botUrl
 
@@ -882,21 +962,21 @@ use the applicationUrl field instead
 
 ##### Defined in
 
-[index.ts:337](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L337)
+[index.ts:377](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L377)
 
----
+___
 
 #### headers
 
-• **headers**: `Record`\<`string`, `string`\> & \{ `nlx-api-key`: `string` }
+• **headers**: `Record`\<`string`, `string`\> & \{ `nlx-api-key`: `string`  }
 
 Headers to forward to the NLX API.
 
 ##### Defined in
 
-[index.ts:341](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L341)
+[index.ts:381](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L381)
 
----
+___
 
 #### conversationId
 
@@ -906,9 +986,9 @@ Set `conversationId` to continue an existing conversation. If not set, a new con
 
 ##### Defined in
 
-[index.ts:351](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L351)
+[index.ts:391](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L391)
 
----
+___
 
 #### userId
 
@@ -918,9 +998,9 @@ Setting the `userID` allows it to be searchable in application history, as well 
 
 ##### Defined in
 
-[index.ts:355](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L355)
+[index.ts:395](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L395)
 
----
+___
 
 #### responses
 
@@ -930,9 +1010,9 @@ When `responses` is set, initialize the chatHandler with historical messages.
 
 ##### Defined in
 
-[index.ts:359](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L359)
+[index.ts:399](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L399)
 
----
+___
 
 #### failureMessage
 
@@ -942,9 +1022,9 @@ When set, this overrides the default failure message ("We encountered an issue. 
 
 ##### Defined in
 
-[index.ts:363](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L363)
+[index.ts:403](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L403)
 
----
+___
 
 #### languageCode
 
@@ -955,9 +1035,21 @@ If you don't have translations, hard-code this to the language code you support.
 
 ##### Defined in
 
-[index.ts:368](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L368)
+[index.ts:408](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L408)
 
----
+___
+
+#### bidirectional
+
+• `Optional` **bidirectional**: `boolean`
+
+Specifies whether the conversation is bidirectional
+
+##### Defined in
+
+[index.ts:417](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L417)
+
+___
 
 #### experimental
 
@@ -967,14 +1059,15 @@ Experimental settings
 
 ##### Type declaration
 
-| Name              | Type      | Description                                                                                                                                                        |
-| :---------------- | :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `channelType?`    | `string`  | Simulate alternative channel types                                                                                                                                 |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `channelType?` | `string` | Simulate alternative channel types |
 | `completeBotUrl?` | `boolean` | Prevent the `languageCode` parameter to be appended to the application URL - used in special deployment environments such as the sandbox chat inside Dialog Studio |
 
 ##### Defined in
 
-[index.ts:377](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L377)
+[index.ts:421](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L421)
+
 
 <a name="interfacesconversationhandlermd"></a>
 
@@ -996,9 +1089,9 @@ Send user's message
 
 ###### Parameters
 
-| Name       | Type                  | Description                                                                                                                               |
-| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `text`     | `string`              | the user's message                                                                                                                        |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `text` | `string` | the user's message |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1007,9 +1100,9 @@ Send user's message
 
 ##### Defined in
 
-[index.ts:606](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L606)
+[index.ts:668](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L668)
 
----
+___
 
 #### sendSlots
 
@@ -1023,10 +1116,10 @@ Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settin
 
 ###### Parameters
 
-| Name       | Type                                        | Description                                                                                                                               |
-| :--------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `slots`    | [`SlotsRecordOrArray`](#slotsrecordorarray) | The slots to populate                                                                                                                     |
-| `context?` | [`Context`](#context)                       | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `slots` | [`SlotsRecordOrArray`](#slotsrecordorarray) | The slots to populate |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
 
@@ -1034,9 +1127,9 @@ Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settin
 
 ##### Defined in
 
-[index.ts:612](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L612)
+[index.ts:674](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L674)
 
----
+___
 
 #### sendChoice
 
@@ -1050,11 +1143,11 @@ Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows
 
 ###### Parameters
 
-| Name        | Type                                                          | Description                                                                                                                               |
-| :---------- | :------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `choiceId`  | `string`                                                      | -                                                                                                                                         |
-| `context?`  | [`Context`](#context)                                         | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
-| `metadata?` | [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd) | links the choice to the specific message and node in the conversation.                                                                    |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `choiceId` | `string` | - |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| `metadata?` | [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd) | links the choice to the specific message and node in the conversation. |
 
 ###### Returns
 
@@ -1062,15 +1155,15 @@ Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows
 
 ##### Defined in
 
-[index.ts:619](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L619)
+[index.ts:681](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L681)
 
----
+___
 
-#### sendWelcomeIntent
+#### sendWelcomeFlow
 
-• **sendWelcomeIntent**: (`context?`: [`Context`](#context)) => `void`
+• **sendWelcomeFlow**: (`context?`: [`Context`](#context)) => `void`
 
-Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents). This should be done when the user starts interacting with the chat.
+Trigger the welcome flow. This should be done when the user starts interacting with the chat.
 
 ##### Type declaration
 
@@ -1078,8 +1171,8 @@ Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-
 
 ###### Parameters
 
-| Name       | Type                  | Description                                                                                                                               |
-| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1088,9 +1181,66 @@ Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-
 
 ##### Defined in
 
-[index.ts:629](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L629)
+[index.ts:691](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L691)
 
----
+___
+
+#### sendWelcomeIntent
+
+• **sendWelcomeIntent**: (`context?`: [`Context`](#context)) => `void`
+
+Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents). This should be done when the user starts interacting with the chat.
+
+**`Deprecated`**
+
+use `sendWelcomeFlow` instead
+
+##### Type declaration
+
+▸ (`context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:698](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L698)
+
+___
+
+#### sendFlow
+
+• **sendFlow**: (`flowId`: `string`, `context?`: [`Context`](#context)) => `void`
+
+Trigger a specific flow.
+
+##### Type declaration
+
+▸ (`flowId`, `context?`): `void`
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `flowId` | `string` | the flow to trigger. The id is the name under the application's _Intents_. |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:705](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L705)
+
+___
 
 #### sendIntent
 
@@ -1098,15 +1248,19 @@ Trigger the welcome [intent](https://docs.studio.nlx.ai/intents/introduction-to-
 
 Trigger a specific [intent](https://docs.studio.nlx.ai/intents/introduction-to-intents).
 
+**`Deprecated`**
+
+use `sendFlow` instead
+
 ##### Type declaration
 
 ▸ (`intentId`, `context?`): `void`
 
 ###### Parameters
 
-| Name       | Type                  | Description                                                                                                                               |
-| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `intentId` | `string`              | the intent to trigger. The id is the name under the application's _Intents_.                                                              |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `intentId` | `string` | the intent to trigger. The id is the name under the application's _Intents_. |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1115,39 +1269,25 @@ Trigger a specific [intent](https://docs.studio.nlx.ai/intents/introduction-to-i
 
 ##### Defined in
 
-[index.ts:636](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L636)
+[index.ts:713](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L713)
 
----
+___
 
-#### getLiveKitCredentials
+#### sendContext
 
-• **getLiveKitCredentials**: () => `Promise`\<[`LiveKitCredentials`](#interfaceslivekitcredentialsmd)\>
+• **sendContext**: (`context`: [`Context`](#context)) => `Promise`\<`void`\>
 
-Obtain LiveKit credentials to run the experience in voice.
-
-##### Type declaration
-
-▸ (): `Promise`\<[`LiveKitCredentials`](#interfaceslivekitcredentialsmd)\>
-
-###### Returns
-
-`Promise`\<[`LiveKitCredentials`](#interfaceslivekitcredentialsmd)\>
-
-##### Defined in
-
-[index.ts:643](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L643)
-
----
-
-#### terminateLiveKitCall
-
-• **terminateLiveKitCall**: () => `Promise`\<`void`\>
-
-Terminate LiveKit call
+Send context without sending a message
 
 ##### Type declaration
 
-▸ (): `Promise`\<`void`\>
+▸ (`context`): `Promise`\<`void`\>
+
+###### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `context` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
 
@@ -1155,9 +1295,35 @@ Terminate LiveKit call
 
 ##### Defined in
 
-[index.ts:649](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L649)
+[index.ts:719](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L719)
 
----
+___
+
+#### getVoiceCredentials
+
+• **getVoiceCredentials**: (`context?`: [`Context`](#context)) => `Promise`\<[`VoiceCredentials`](#interfacesvoicecredentialsmd)\>
+
+Obtain Voice credentials to run the experience in voice.
+
+##### Type declaration
+
+▸ (`context?`): `Promise`\<[`VoiceCredentials`](#interfacesvoicecredentialsmd)\>
+
+###### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `context?` | [`Context`](#context) |
+
+###### Returns
+
+`Promise`\<[`VoiceCredentials`](#interfacesvoicecredentialsmd)\>
+
+##### Defined in
+
+[index.ts:726](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L726)
+
+___
 
 #### sendStructured
 
@@ -1171,10 +1337,10 @@ Send a combination of choice, slots, and intent in one request.
 
 ###### Parameters
 
-| Name       | Type                                                  | Description                                                                                                                               |
-| :--------- | :---------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `request`  | [`StructuredRequest`](#interfacesstructuredrequestmd) |                                                                                                                                           |
-| `context?` | [`Context`](#context)                                 | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `request` | [`StructuredRequest`](#interfacesstructuredrequestmd) |  |
+| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
 
@@ -1182,9 +1348,9 @@ Send a combination of choice, slots, and intent in one request.
 
 ##### Defined in
 
-[index.ts:656](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L656)
+[index.ts:733](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L733)
 
----
+___
 
 #### subscribe
 
@@ -1198,8 +1364,8 @@ Subscribe a callback to the conversation. On subscribe, the subscriber will rece
 
 ###### Parameters
 
-| Name         | Type                        | Description               |
-| :----------- | :-------------------------- | :------------------------ |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `subscriber` | [`Subscriber`](#subscriber) | The callback to subscribe |
 
 ###### Returns
@@ -1214,9 +1380,9 @@ Subscribe a callback to the conversation. On subscribe, the subscriber will rece
 
 ##### Defined in
 
-[index.ts:661](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L661)
+[index.ts:738](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L738)
 
----
+___
 
 #### unsubscribe
 
@@ -1230,8 +1396,8 @@ Unsubscribe a callback from the conversation.
 
 ###### Parameters
 
-| Name         | Type                        | Description                 |
-| :----------- | :-------------------------- | :-------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `subscriber` | [`Subscriber`](#subscriber) | The callback to unsubscribe |
 
 ###### Returns
@@ -1240,9 +1406,9 @@ Unsubscribe a callback from the conversation.
 
 ##### Defined in
 
-[index.ts:666](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L666)
+[index.ts:743](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L743)
 
----
+___
 
 #### unsubscribeAll
 
@@ -1260,9 +1426,9 @@ Unsubscribe all callback from the conversation.
 
 ##### Defined in
 
-[index.ts:670](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L670)
+[index.ts:747](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L747)
 
----
+___
 
 #### currentConversationId
 
@@ -1280,9 +1446,9 @@ Get the current conversation ID if it's set, or undefined if there is no convers
 
 ##### Defined in
 
-[index.ts:674](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L674)
+[index.ts:751](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L751)
 
----
+___
 
 #### currentLanguageCode
 
@@ -1300,9 +1466,9 @@ Get the current language code
 
 ##### Defined in
 
-[index.ts:678](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L678)
+[index.ts:755](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L755)
 
----
+___
 
 #### setLanguageCode
 
@@ -1316,8 +1482,8 @@ Set the language code
 
 ###### Parameters
 
-| Name           | Type     |
-| :------------- | :------- |
+| Name | Type |
+| :------ | :------ |
 | `languageCode` | `string` |
 
 ###### Returns
@@ -1326,13 +1492,13 @@ Set the language code
 
 ##### Defined in
 
-[index.ts:682](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L682)
+[index.ts:759](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L759)
 
----
+___
 
 #### reset
 
-• **reset**: (`options?`: \{ `clearResponses?`: `boolean` }) => `void`
+• **reset**: (`options?`: \{ `clearResponses?`: `boolean`  }) => `void`
 
 Forces a new conversation. If `clearResponses` is set to true, will also clear historical responses passed to subscribers.
 Retains all existing subscribers.
@@ -1343,9 +1509,9 @@ Retains all existing subscribers.
 
 ###### Parameters
 
-| Name                      | Type      | Description                                                            |
-| :------------------------ | :-------- | :--------------------------------------------------------------------- |
-| `options?`                | `Object`  | -                                                                      |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `Object` | - |
 | `options.clearResponses?` | `boolean` | If set to true, will clear historical responses passed to subscribers. |
 
 ###### Returns
@@ -1354,9 +1520,9 @@ Retains all existing subscribers.
 
 ##### Defined in
 
-[index.ts:687](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L687)
+[index.ts:764](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L764)
 
----
+___
 
 #### destroy
 
@@ -1374,15 +1540,19 @@ Removes all subscribers and, if using websockets, closes the connection.
 
 ##### Defined in
 
-[index.ts:696](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L696)
+[index.ts:773](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L773)
 
----
+___
 
 #### setBotRequestOverride
 
-• **setBotRequestOverride**: (`override`: `undefined` \| [`BotRequestOverride`](#botrequestoverride)) => `void`
+• **setBotRequestOverride**: (`override`: `undefined` \| [`RequestOverride`](#requestoverride)) => `void`
 
-Optional [BotRequestOverride](#botrequestoverride) function used to bypass the bot request and handle them in a custom fashion
+Optional [RequestOverride](#requestoverride) function used to bypass the bot request and handle them in a custom fashion
+
+**`Deprecated`**
+
+use `setRequestOverride` instead
 
 ##### Type declaration
 
@@ -1390,9 +1560,9 @@ Optional [BotRequestOverride](#botrequestoverride) function used to bypass the b
 
 ###### Parameters
 
-| Name       | Type                                                       |
-| :--------- | :--------------------------------------------------------- |
-| `override` | `undefined` \| [`BotRequestOverride`](#botrequestoverride) |
+| Name | Type |
+| :------ | :------ |
+| `override` | `undefined` \| [`RequestOverride`](#requestoverride) |
 
 ###### Returns
 
@@ -1400,13 +1570,39 @@ Optional [BotRequestOverride](#botrequestoverride) function used to bypass the b
 
 ##### Defined in
 
-[index.ts:700](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L700)
+[index.ts:778](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L778)
 
----
+___
+
+#### setRequestOverride
+
+• **setRequestOverride**: (`override`: `undefined` \| [`RequestOverride`](#requestoverride)) => `void`
+
+Optional [RequestOverride](#requestoverride) function used to bypass the bot request and handle them in a custom fashion
+
+##### Type declaration
+
+▸ (`override`): `void`
+
+###### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `override` | `undefined` \| [`RequestOverride`](#requestoverride) |
+
+###### Returns
+
+`void`
+
+##### Defined in
+
+[index.ts:782](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L782)
+
+___
 
 #### addEventListener
 
-• **addEventListener**: (`event`: `"voicePlusCommand"`, `handler`: (`payload`: `any`) => `void`) => `void`
+• **addEventListener**: (`event`: ``"voicePlusCommand"``, `handler`: (`payload`: `any`) => `void`) => `void`
 
 Add a listener to one of the handler's custom events
 
@@ -1416,9 +1612,9 @@ Add a listener to one of the handler's custom events
 
 ###### Parameters
 
-| Name      | Type                         |
-| :-------- | :--------------------------- |
-| `event`   | `"voicePlusCommand"`         |
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"voicePlusCommand"`` |
 | `handler` | (`payload`: `any`) => `void` |
 
 ###### Returns
@@ -1427,13 +1623,13 @@ Add a listener to one of the handler's custom events
 
 ##### Defined in
 
-[index.ts:704](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L704)
+[index.ts:786](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L786)
 
----
+___
 
 #### removeEventListener
 
-• **removeEventListener**: (`event`: `"voicePlusCommand"`, `handler`: (`payload`: `any`) => `void`) => `void`
+• **removeEventListener**: (`event`: ``"voicePlusCommand"``, `handler`: (`payload`: `any`) => `void`) => `void`
 
 Remove a listener to one of the handler's custom events
 
@@ -1443,9 +1639,9 @@ Remove a listener to one of the handler's custom events
 
 ###### Parameters
 
-| Name      | Type                         |
-| :-------- | :--------------------------- |
-| `event`   | `"voicePlusCommand"`         |
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"voicePlusCommand"`` |
 | `handler` | (`payload`: `any`) => `void` |
 
 ###### Returns
@@ -1454,9 +1650,9 @@ Remove a listener to one of the handler's custom events
 
 ##### Defined in
 
-[index.ts:711](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L711)
+[index.ts:793](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L793)
 
----
+___
 
 #### sendVoicePlusContext
 
@@ -1470,8 +1666,8 @@ Send voicePlus message
 
 ###### Parameters
 
-| Name      | Type  |
-| :-------- | :---- |
+| Name | Type |
+| :------ | :------ |
 | `context` | `any` |
 
 ###### Returns
@@ -1480,7 +1676,8 @@ Send voicePlus message
 
 ##### Defined in
 
-[index.ts:718](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L718)
+[index.ts:800](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L800)
+
 
 <a name="interfaceseventhandlersmd"></a>
 
@@ -1502,8 +1699,8 @@ Voice+ command event handler
 
 ###### Parameters
 
-| Name      | Type  |
-| :-------- | :---- |
+| Name | Type |
+| :------ | :------ |
 | `payload` | `any` |
 
 ###### Returns
@@ -1512,7 +1709,8 @@ Voice+ command event handler
 
 ##### Defined in
 
-[index.ts:594](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L594)
+[index.ts:656](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L656)
+
 
 <a name="interfacesfailuremessagemd"></a>
 
@@ -1524,15 +1722,15 @@ A failure message is received when the NLX api is unreachable, or sends an unpar
 
 #### type
 
-• **type**: `"failure"`
+• **type**: ``"failure"``
 
 The type of the response is `"bot"` for bot and `"user"` for user.
 
 ##### Defined in
 
-[index.ts:292](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L292)
+[index.ts:332](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L332)
 
----
+___
 
 #### payload
 
@@ -1542,15 +1740,15 @@ The payload only includes an error message.
 
 ##### Type declaration
 
-| Name   | Type     | Description                                                                                                |
-| :----- | :------- | :--------------------------------------------------------------------------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `text` | `string` | The error message is either the default, or the `failureMessage` set in the [Config](#interfacesconfigmd). |
 
 ##### Defined in
 
-[index.ts:296](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L296)
+[index.ts:336](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L336)
 
----
+___
 
 #### receivedAt
 
@@ -1560,61 +1758,75 @@ When the failure occurred.
 
 ##### Defined in
 
-[index.ts:305](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L305)
+[index.ts:345](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L345)
 
-<a name="interfaceslivekitcredentialsmd"></a>
 
-## Interface: LiveKitCredentials
+<a name="interfacesknowledgebaseresponsesourcemd"></a>
 
-Credentials to connect to a LiveKit channel
+## Interface: KnowledgeBaseResponseSource
+
+Response for knowlege base sources
 
 ### Properties
 
-#### url
+#### fileName
 
-• **url**: `string`
+• `Optional` **fileName**: `string`
 
-LiveKit URL
-
-##### Defined in
-
-[index.ts:510](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L510)
-
----
-
-#### roomName
-
-• **roomName**: `string`
-
-LiveKit room name
+File name
 
 ##### Defined in
 
-[index.ts:514](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L514)
+[index.ts:161](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L161)
 
----
+___
 
-#### token
+#### pageNumber
 
-• **token**: `string`
+• `Optional` **pageNumber**: `number`
 
-LiveKit token
-
-##### Defined in
-
-[index.ts:518](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L518)
-
----
-
-#### participantName
-
-• **participantName**: `string`
-
-LiveKit participant name
+Page number
 
 ##### Defined in
 
-[index.ts:522](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L522)
+[index.ts:165](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L165)
+
+___
+
+#### content
+
+• `Optional` **content**: `string`
+
+Content
+
+##### Defined in
+
+[index.ts:169](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L169)
+
+___
+
+#### metadata
+
+• `Optional` **metadata**: `Record`\<`string`, `unknown`\>
+
+Metadata
+
+##### Defined in
+
+[index.ts:173](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L173)
+
+___
+
+#### presignedUrl
+
+• `Optional` **presignedUrl**: `string`
+
+Presigned URL for direct retrieval
+
+##### Defined in
+
+[index.ts:177](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L177)
+
 
 <a name="interfacesslotvaluemd"></a>
 
@@ -1634,9 +1846,9 @@ The attached slot's name
 
 ##### Defined in
 
-[index.ts:24](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L24)
+[index.ts:29](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L29)
 
----
+___
 
 #### value
 
@@ -1647,7 +1859,8 @@ for custom slots, this can optionally be the value's ID.
 
 ##### Defined in
 
-[index.ts:29](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L29)
+[index.ts:34](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L34)
+
 
 <a name="interfacesstructuredrequestmd"></a>
 
@@ -1666,9 +1879,9 @@ The `choiceId` is in the [BotResponse](#interfacesbotresponsemd)'s `.payload.mes
 
 ##### Defined in
 
-[index.ts:423](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L423)
+[index.ts:468](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L468)
 
----
+___
 
 #### nodeId
 
@@ -1679,9 +1892,9 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 ##### Defined in
 
-[index.ts:428](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L428)
+[index.ts:473](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L473)
 
----
+___
 
 #### intentId
 
@@ -1689,11 +1902,27 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 The intent to trigger. The `intentId` is the name under the application's _Intents_.
 
+**`Deprecated`**
+
+use `flowId` instead.
+
 ##### Defined in
 
-[index.ts:432](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L432)
+[index.ts:478](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L478)
 
----
+___
+
+#### flowId
+
+• `Optional` **flowId**: `string`
+
+The flow to trigger. The `flowId` is the name under the application's _Flows_.
+
+##### Defined in
+
+[index.ts:482](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L482)
+
+___
 
 #### slots
 
@@ -1703,9 +1932,9 @@ The slots to populate
 
 ##### Defined in
 
-[index.ts:436](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L436)
+[index.ts:486](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L486)
 
----
+___
 
 #### uploadIds
 
@@ -1715,9 +1944,9 @@ Upload ID
 
 ##### Defined in
 
-[index.ts:440](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L440)
+[index.ts:490](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L490)
 
----
+___
 
 #### utterance
 
@@ -1727,7 +1956,8 @@ Upload utterance
 
 ##### Defined in
 
-[index.ts:444](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L444)
+[index.ts:494](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L494)
+
 
 <a name="interfacesuploadurlmd"></a>
 
@@ -1745,9 +1975,9 @@ The URL of the upload
 
 ##### Defined in
 
-[index.ts:190](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L190)
+[index.ts:230](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L230)
 
----
+___
 
 #### uploadId
 
@@ -1757,7 +1987,8 @@ The ID of the upload
 
 ##### Defined in
 
-[index.ts:194](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L194)
+[index.ts:234](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L234)
+
 
 <a name="interfacesuserresponsemd"></a>
 
@@ -1766,7 +1997,6 @@ The ID of the upload
 A message from the user
 
 See also:
-
 - [BotResponse](#interfacesbotresponsemd)
 - [FailureMessage](#interfacesfailuremessagemd)
 - [Response](#response)
@@ -1775,15 +2005,15 @@ See also:
 
 #### type
 
-• **type**: `"user"`
+• **type**: ``"user"``
 
 The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
 
 ##### Defined in
 
-[index.ts:228](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L228)
+[index.ts:268](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L268)
 
----
+___
 
 #### receivedAt
 
@@ -1793,9 +2023,9 @@ When the response was received
 
 ##### Defined in
 
-[index.ts:232](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L232)
+[index.ts:272](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L272)
 
----
+___
 
 #### payload
 
@@ -1805,7 +2035,63 @@ The payload of the response
 
 ##### Defined in
 
-[index.ts:236](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L236)
+[index.ts:276](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L276)
+
+
+<a name="interfacesvoicecredentialsmd"></a>
+
+## Interface: VoiceCredentials
+
+Credentials to connect to a Voice channel
+
+### Properties
+
+#### url
+
+• **url**: `string`
+
+Voice Connection URL
+
+##### Defined in
+
+[index.ts:566](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L566)
+
+___
+
+#### roomName
+
+• **roomName**: `string`
+
+Voice room name
+
+##### Defined in
+
+[index.ts:570](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L570)
+
+___
+
+#### token
+
+• **token**: `string`
+
+Voice token
+
+##### Defined in
+
+[index.ts:574](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L574)
+
+___
+
+#### participantName
+
+• **participantName**: `string`
+
+Voice participant name
+
+##### Defined in
+
+[index.ts:578](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L578)
+
 
 <a name="interfacesvoiceplusmessagemd"></a>
 
@@ -1823,4 +2109,4 @@ Voice+ context
 
 ##### Defined in
 
-[index.ts:579](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-core/src/index.ts#L579)
+[index.ts:641](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L641)

--- a/packages/website/src/content/headless-api-reference.md
+++ b/packages/website/src/content/headless-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/chat-core
@@ -37,7 +36,7 @@
 
 [index.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L18)
 
-___
+---
 
 ### SlotsRecord
 
@@ -56,7 +55,7 @@ A `SlotsRecord` is equivalent to an array of [SlotValue](#interfacesslotvaluemd)
 
 [index.ts:47](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L47)
 
-___
+---
 
 ### SlotsRecordOrArray
 
@@ -70,7 +69,7 @@ Supports either a [SlotsRecord](#slotsrecord) or an array of [SlotValue](#interf
 
 [index.ts:54](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L54)
 
-___
+---
 
 ### ModalityPayloads
 
@@ -82,11 +81,11 @@ Payloads for modalities as a key-value pair by modality name
 
 [index.ts:117](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L117)
 
-___
+---
 
 ### UserResponsePayload
 
-Ƭ **UserResponsePayload**: \{ `type`: ``"text"`` ; `text`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"choice"`` ; `choiceId`: `string` ; `context?`: [`Context`](#context)  } \| \{ `type`: ``"structured"`` ; `context?`: [`Context`](#context)  } & [`StructuredRequest`](#interfacesstructuredrequestmd)
+Ƭ **UserResponsePayload**: \{ `type`: `"text"` ; `text`: `string` ; `context?`: [`Context`](#context) } \| \{ `type`: `"choice"` ; `choiceId`: `string` ; `context?`: [`Context`](#context) } \| \{ `type`: `"structured"` ; `context?`: [`Context`](#context) } & [`StructuredRequest`](#interfacesstructuredrequestmd)
 
 The payload of the user response
 
@@ -94,7 +93,7 @@ The payload of the user response
 
 [index.ts:282](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L282)
 
-___
+---
 
 ### Response
 
@@ -106,7 +105,7 @@ A response from the application or the user.
 
 [index.ts:351](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L351)
 
-___
+---
 
 ### Time
 
@@ -118,11 +117,11 @@ The time value in milliseconds since midnight, January 1, 1970 UTC.
 
 [index.ts:356](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L356)
 
-___
+---
 
 ### NormalizedStructuredRequest
 
-Ƭ **NormalizedStructuredRequest**: [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[]  }
+Ƭ **NormalizedStructuredRequest**: [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[] }
 
 Normalized structured request with a single way to represent slots
 
@@ -130,7 +129,7 @@ Normalized structured request with a single way to represent slots
 
 [index.ts:505](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L505)
 
-___
+---
 
 ### BotRequest
 
@@ -146,7 +145,7 @@ use [ApplicationRequest](#interfacesapplicationrequestmd)
 
 [index.ts:557](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L557)
 
-___
+---
 
 ### LanguageCode
 
@@ -158,7 +157,7 @@ Language code named for clarity, may restrict it to a finite list
 
 [index.ts:611](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L611)
 
-___
+---
 
 ### RequestOverride
 
@@ -172,9 +171,9 @@ Instead of sending a request to the application, handle it in a custom fashion
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `botRequest` | [`BotRequest`](#botrequest) | The [BotRequest](#botrequest) that is being overridden |
+| Name             | Type                                                                       | Description                                                                                         |
+| :--------------- | :------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| `botRequest`     | [`BotRequest`](#botrequest)                                                | The [BotRequest](#botrequest) that is being overridden                                              |
 | `appendResponse` | (`res`: [`BotResponsePayload`](#interfacesbotresponsepayloadmd)) => `void` | A method to append the [BotResponsePayload](#interfacesbotresponsepayloadmd) to the message history |
 
 ##### Returns
@@ -185,7 +184,7 @@ Instead of sending a request to the application, handle it in a custom fashion
 
 [index.ts:618](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L618)
 
-___
+---
 
 ### BotRequestOverride
 
@@ -201,7 +200,7 @@ use [RequestOverride](#requestoverride) instead
 
 [index.ts:627](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L627)
 
-___
+---
 
 ### VoicePlusContext
 
@@ -213,11 +212,11 @@ Voice+ context, type to be defined
 
 [index.ts:632](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L632)
 
-___
+---
 
 ### ConversationHandlerEvent
 
-Ƭ **ConversationHandlerEvent**: ``"voicePlusCommand"``
+Ƭ **ConversationHandlerEvent**: `"voicePlusCommand"`
 
 Handler events
 
@@ -225,7 +224,7 @@ Handler events
 
 [index.ts:647](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L647)
 
-___
+---
 
 ### Subscriber
 
@@ -239,10 +238,10 @@ The callback function for listening to all responses.
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `response` | [`Response`](#response)[] |
-| `newResponse?` | [`Response`](#response) |
+| Name           | Type                      |
+| :------------- | :------------------------ |
+| `response`     | [`Response`](#response)[] |
+| `newResponse?` | [`Response`](#response)   |
 
 ##### Returns
 
@@ -277,8 +276,8 @@ The order of configs doesn't matter.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type                            |
+| :-------- | :------------------------------ |
 | `config1` | [`Config`](#interfacesconfigmd) |
 | `config2` | [`Config`](#interfacesconfigmd) |
 
@@ -292,7 +291,7 @@ true if `createConversation` should be called again
 
 [index.ts:836](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L836)
 
-___
+---
 
 ### isConfigValid
 
@@ -302,8 +301,8 @@ Check whether a configuration is value.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name     | Type                            | Description        |
+| :------- | :------------------------------ | :----------------- |
 | `config` | [`Config`](#interfacesconfigmd) | Chat configuration |
 
 #### Returns
@@ -316,7 +315,7 @@ isValid - Whether the configuration is valid
 
 [index.ts:891](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L891)
 
-___
+---
 
 ### createConversation
 
@@ -326,8 +325,8 @@ Call this to create a conversation handler.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                            |
+| :------- | :------------------------------ |
 | `config` | [`Config`](#interfacesconfigmd) |
 
 #### Returns
@@ -340,23 +339,23 @@ The [ConversationHandler](#interfacesconversationhandlermd) is a bundle of funct
 
 [index.ts:903](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L903)
 
-___
+---
 
 ### getCurrentExpirationTimestamp
 
-▸ **getCurrentExpirationTimestamp**(`responses`): ``null`` \| `number`
+▸ **getCurrentExpirationTimestamp**(`responses`): `null` \| `number`
 
 Get current expiration timestamp from the current list of reponses
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name        | Type                      | Description                                                                           |
+| :---------- | :------------------------ | :------------------------------------------------------------------------------------ |
 | `responses` | [`Response`](#response)[] | the current list of user and bot responses (first argument in the subscribe callback) |
 
 #### Returns
 
-``null`` \| `number`
+`null` \| `number`
 
 an expiration timestamp in Unix Epoch (`new Date().getTime()`), or `null` if this is not known (typically occurs if the bot has not responded yet)
 
@@ -364,11 +363,11 @@ an expiration timestamp in Unix Epoch (`new Date().getTime()`), or `null` if thi
 
 [index.ts:1488](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L1488)
 
-___
+---
 
 ### promisify
 
-▸ **promisify**\<`T`\>(`fn`, `convo`, `timeout?`): (`payload`: `T`) => `Promise`\<[`Response`](#response) \| ``null``\>
+▸ **promisify**\<`T`\>(`fn`, `convo`, `timeout?`): (`payload`: `T`) => `Promise`\<[`Response`](#response) \| `null`\>
 
 This package is intentionally designed with a subscription-based API as opposed to a promise-based one where each message corresponds to a single bot response, available asynchronously.
 
@@ -376,17 +375,17 @@ If you need a promise-based wrapper, you can use the `promisify` helper availabl
 
 #### Type parameters
 
-| Name | Description |
-| :------ | :------ |
-| `T` | the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context` |
+| Name | Description                                                                                   |
+| :--- | :-------------------------------------------------------------------------------------------- |
+| `T`  | the type of the function's params, e.g. for `sendText` it's `text: string, context?: Context` |
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `fn` | (`payload`: `T`) => `void` | `undefined` | the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.) |
-| `convo` | [`ConversationHandler`](#interfacesconversationhandlermd) | `undefined` | the `ConversationHandler` (from [createConversation](#createconversation)) |
-| `timeout` | `number` | `10000` | the timeout in milliseconds |
+| Name      | Type                                                      | Default value | Description                                                                |
+| :-------- | :-------------------------------------------------------- | :------------ | :------------------------------------------------------------------------- |
+| `fn`      | (`payload`: `T`) => `void`                                | `undefined`   | the function to wrap (e.g. `convo.sendText`, `convo.sendChoice`, etc.)     |
+| `convo`   | [`ConversationHandler`](#interfacesconversationhandlermd) | `undefined`   | the `ConversationHandler` (from [createConversation](#createconversation)) |
+| `timeout` | `number`                                                  | `10000`       | the timeout in milliseconds                                                |
 
 #### Returns
 
@@ -394,17 +393,17 @@ If you need a promise-based wrapper, you can use the `promisify` helper availabl
 
 A promise-wrapped version of the function. The function, when called, returns a promise that resolves to the Conversation's next response.
 
-▸ (`payload`): `Promise`\<[`Response`](#response) \| ``null``\>
+▸ (`payload`): `Promise`\<[`Response`](#response) \| `null`\>
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `payload` | `T` |
+| Name      | Type |
+| :-------- | :--- |
+| `payload` | `T`  |
 
 ##### Returns
 
-`Promise`\<[`Response`](#response) \| ``null``\>
+`Promise`\<[`Response`](#response) \| `null`\>
 
 **`Example`**
 
@@ -424,12 +423,9 @@ sendTextWrapped("Hello").then((response) => {
 
 [index.ts:1525](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L1525)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfacesapplicationrequestmd"></a>
 
@@ -449,7 +445,7 @@ The current conversation ID
 
 [index.ts:519](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L519)
 
-___
+---
 
 #### userId
 
@@ -461,7 +457,7 @@ The current user ID
 
 [index.ts:523](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L523)
 
-___
+---
 
 #### context
 
@@ -473,7 +469,7 @@ Request context, if applicable
 
 [index.ts:527](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L527)
 
-___
+---
 
 #### request
 
@@ -483,16 +479,15 @@ Main request
 
 ##### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `unstructured?` | \{ `text`: `string`  } | Unstructured request |
-| `unstructured.text` | `string` | Request body text |
-| `structured?` | [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[]  } | Structured request |
+| Name                | Type                                                                                                           | Description          |
+| :------------------ | :------------------------------------------------------------------------------------------------------------- | :------------------- |
+| `unstructured?`     | \{ `text`: `string` }                                                                                          | Unstructured request |
+| `unstructured.text` | `string`                                                                                                       | Request body text    |
+| `structured?`       | [`StructuredRequest`](#interfacesstructuredrequestmd) & \{ `slots?`: [`SlotValue`](#interfacesslotvaluemd)[] } | Structured request   |
 
 ##### Defined in
 
 [index.ts:531](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L531)
-
 
 <a name="interfacesbotmessagemd"></a>
 
@@ -512,7 +507,7 @@ A unique identifier for the message.
 
 [index.ts:198](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L198)
 
-___
+---
 
 #### nodeId
 
@@ -525,7 +520,7 @@ This is must be sent with a choice when the user is changing a previously sent c
 
 [index.ts:203](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L203)
 
-___
+---
 
 #### text
 
@@ -537,7 +532,7 @@ The body of the message. Show this to the user.
 
 [index.ts:207](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L207)
 
-___
+---
 
 #### choices
 
@@ -549,7 +544,7 @@ A selection of choices to show to the user. They may choose one of them.
 
 [index.ts:211](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L211)
 
-___
+---
 
 #### metadata
 
@@ -561,7 +556,7 @@ Metadata
 
 [index.ts:215](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L215)
 
-___
+---
 
 #### selectedChoiceId
 
@@ -573,7 +568,6 @@ This field is set locally and does not come from the application.
 ##### Defined in
 
 [index.ts:220](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L220)
-
 
 <a name="interfacesbotmessagemetadatamd"></a>
 
@@ -594,7 +588,6 @@ The message node's intent
 
 [index.ts:188](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L188)
 
-
 <a name="interfacesbotresponsemd"></a>
 
 ## Interface: BotResponse
@@ -602,6 +595,7 @@ The message node's intent
 A message from the application
 
 See also:
+
 - [UserResponse](#interfacesuserresponsemd)
 - [FailureMessage](#interfacesfailuremessagemd)
 - [Response](#response)
@@ -610,7 +604,7 @@ See also:
 
 #### type
 
-• **type**: ``"bot"``
+• **type**: `"bot"`
 
 The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
 
@@ -618,7 +612,7 @@ The type of the response is `"bot"` for bot and `"user"` for user, and "failure"
 
 [index.ts:68](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L68)
 
-___
+---
 
 #### receivedAt
 
@@ -630,7 +624,7 @@ When the response was received
 
 [index.ts:72](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L72)
 
-___
+---
 
 #### payload
 
@@ -641,7 +635,6 @@ The payload of the response
 ##### Defined in
 
 [index.ts:76](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L76)
-
 
 <a name="interfacesbotresponsemetadatamd"></a>
 
@@ -662,7 +655,7 @@ The conversation's intent
 
 [index.ts:127](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L127)
 
-___
+---
 
 #### escalation
 
@@ -674,7 +667,7 @@ Whether the current conversation has been marked as incomprehension.
 
 [index.ts:131](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L131)
 
-___
+---
 
 #### frustration
 
@@ -686,7 +679,7 @@ Whether the current conversation has been marked frustrated
 
 [index.ts:135](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L135)
 
-___
+---
 
 #### incomprehension
 
@@ -698,7 +691,7 @@ Whether the current conversation has been marked as incomprehension.
 
 [index.ts:139](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L139)
 
-___
+---
 
 #### uploadUrls
 
@@ -710,7 +703,7 @@ Upload URL's
 
 [index.ts:143](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L143)
 
-___
+---
 
 #### hasPendingDataRequest
 
@@ -722,7 +715,7 @@ Whether the client should poll for more application responses.
 
 [index.ts:147](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L147)
 
-___
+---
 
 #### sources
 
@@ -733,7 +726,6 @@ Knowledge base sources
 ##### Defined in
 
 [index.ts:151](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L151)
-
 
 <a name="interfacesbotresponsepayloadmd"></a>
 
@@ -753,7 +745,7 @@ If there isn't some interaction by this time, the conversation will expire.
 
 [index.ts:86](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L86)
 
-___
+---
 
 #### conversationId
 
@@ -765,7 +757,7 @@ The active conversation ID. If not set, a new conversation will be started.
 
 [index.ts:90](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L90)
 
-___
+---
 
 #### messages
 
@@ -777,7 +769,7 @@ Any messages from the bot.
 
 [index.ts:94](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L94)
 
-___
+---
 
 #### metadata
 
@@ -790,7 +782,7 @@ as well as whether the client should poll for more application responses.
 
 [index.ts:99](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L99)
 
-___
+---
 
 #### payload
 
@@ -802,7 +794,7 @@ If configured, the [node's payload.](#add-functionality)
 
 [index.ts:103](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L103)
 
-___
+---
 
 #### modalities
 
@@ -814,7 +806,7 @@ If configured, the node's modalities and their payloads.
 
 [index.ts:107](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L107)
 
-___
+---
 
 #### context
 
@@ -825,7 +817,6 @@ If the node is set to send context, the whole context associated with the conver
 ##### Defined in
 
 [index.ts:111](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L111)
-
 
 <a name="interfaceschoicemd"></a>
 
@@ -845,7 +836,7 @@ A choices to show to the user.
 
 [index.ts:244](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L244)
 
-___
+---
 
 #### choiceText
 
@@ -857,7 +848,7 @@ The text of the choice
 
 [index.ts:248](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L248)
 
-___
+---
 
 #### choicePayload
 
@@ -868,7 +859,6 @@ An optional, schemaless payload for the choice.
 ##### Defined in
 
 [index.ts:252](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L252)
-
 
 <a name="interfaceschoicerequestmetadatamd"></a>
 
@@ -890,7 +880,7 @@ It is not sent to the application.
 
 [index.ts:590](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L590)
 
-___
+---
 
 #### messageIndex
 
@@ -904,7 +894,7 @@ It is not sent to the application.
 
 [index.ts:596](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L596)
 
-___
+---
 
 #### nodeId
 
@@ -917,7 +907,7 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 [index.ts:601](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L601)
 
-___
+---
 
 #### intentId
 
@@ -928,7 +918,6 @@ Intent ID, used for sending to the NLU to allow it to double-check
 ##### Defined in
 
 [index.ts:605](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L605)
-
 
 <a name="interfacesconfigmd"></a>
 
@@ -948,7 +937,7 @@ Fetch this from the application's Deployment page.
 
 [index.ts:372](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L372)
 
-___
+---
 
 #### botUrl
 
@@ -964,11 +953,11 @@ use the applicationUrl field instead
 
 [index.ts:377](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L377)
 
-___
+---
 
 #### headers
 
-• **headers**: `Record`\<`string`, `string`\> & \{ `nlx-api-key`: `string`  }
+• **headers**: `Record`\<`string`, `string`\> & \{ `nlx-api-key`: `string` }
 
 Headers to forward to the NLX API.
 
@@ -976,7 +965,7 @@ Headers to forward to the NLX API.
 
 [index.ts:381](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L381)
 
-___
+---
 
 #### conversationId
 
@@ -988,7 +977,7 @@ Set `conversationId` to continue an existing conversation. If not set, a new con
 
 [index.ts:391](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L391)
 
-___
+---
 
 #### userId
 
@@ -1000,7 +989,7 @@ Setting the `userID` allows it to be searchable in application history, as well 
 
 [index.ts:395](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L395)
 
-___
+---
 
 #### responses
 
@@ -1012,7 +1001,7 @@ When `responses` is set, initialize the chatHandler with historical messages.
 
 [index.ts:399](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L399)
 
-___
+---
 
 #### failureMessage
 
@@ -1024,7 +1013,7 @@ When set, this overrides the default failure message ("We encountered an issue. 
 
 [index.ts:403](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L403)
 
-___
+---
 
 #### languageCode
 
@@ -1037,7 +1026,7 @@ If you don't have translations, hard-code this to the language code you support.
 
 [index.ts:408](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L408)
 
-___
+---
 
 #### bidirectional
 
@@ -1049,7 +1038,7 @@ Specifies whether the conversation is bidirectional
 
 [index.ts:417](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L417)
 
-___
+---
 
 #### experimental
 
@@ -1059,15 +1048,14 @@ Experimental settings
 
 ##### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `channelType?` | `string` | Simulate alternative channel types |
+| Name              | Type      | Description                                                                                                                                                        |
+| :---------------- | :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `channelType?`    | `string`  | Simulate alternative channel types                                                                                                                                 |
 | `completeBotUrl?` | `boolean` | Prevent the `languageCode` parameter to be appended to the application URL - used in special deployment environments such as the sandbox chat inside Dialog Studio |
 
 ##### Defined in
 
 [index.ts:421](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L421)
-
 
 <a name="interfacesconversationhandlermd"></a>
 
@@ -1089,9 +1077,9 @@ Send user's message
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `text` | `string` | the user's message |
+| Name       | Type                  | Description                                                                                                                               |
+| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`     | `string`              | the user's message                                                                                                                        |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1102,7 +1090,7 @@ Send user's message
 
 [index.ts:668](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L668)
 
-___
+---
 
 #### sendSlots
 
@@ -1116,10 +1104,10 @@ Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settin
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `slots` | [`SlotsRecordOrArray`](#slotsrecordorarray) | The slots to populate |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| Name       | Type                                        | Description                                                                                                                               |
+| :--------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `slots`    | [`SlotsRecordOrArray`](#slotsrecordorarray) | The slots to populate                                                                                                                     |
+| `context?` | [`Context`](#context)                       | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
 
@@ -1129,7 +1117,7 @@ Send [slots](https://docs.studio.nlx.ai/workspacesettings/introduction-to-settin
 
 [index.ts:674](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L674)
 
-___
+---
 
 #### sendChoice
 
@@ -1143,11 +1131,11 @@ Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `choiceId` | `string` | - |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
-| `metadata?` | [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd) | links the choice to the specific message and node in the conversation. |
+| Name        | Type                                                          | Description                                                                                                                               |
+| :---------- | :------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `choiceId`  | `string`                                                      | -                                                                                                                                         |
+| `context?`  | [`Context`](#context)                                         | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| `metadata?` | [`ChoiceRequestMetadata`](#interfaceschoicerequestmetadatamd) | links the choice to the specific message and node in the conversation.                                                                    |
 
 ###### Returns
 
@@ -1157,7 +1145,7 @@ Respond to [a choice](https://docs.studio.nlx.ai/intentflows/documentation-flows
 
 [index.ts:681](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L681)
 
-___
+---
 
 #### sendWelcomeFlow
 
@@ -1171,8 +1159,8 @@ Trigger the welcome flow. This should be done when the user starts interacting w
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name       | Type                  | Description                                                                                                                               |
+| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1183,7 +1171,7 @@ Trigger the welcome flow. This should be done when the user starts interacting w
 
 [index.ts:691](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L691)
 
-___
+---
 
 #### sendWelcomeIntent
 
@@ -1201,8 +1189,8 @@ use `sendWelcomeFlow` instead
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name       | Type                  | Description                                                                                                                               |
+| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1213,7 +1201,7 @@ use `sendWelcomeFlow` instead
 
 [index.ts:698](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L698)
 
-___
+---
 
 #### sendFlow
 
@@ -1227,9 +1215,9 @@ Trigger a specific flow.
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `flowId` | `string` | the flow to trigger. The id is the name under the application's _Intents_. |
+| Name       | Type                  | Description                                                                                                                               |
+| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `flowId`   | `string`              | the flow to trigger. The id is the name under the application's _Intents_.                                                                |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1240,7 +1228,7 @@ Trigger a specific flow.
 
 [index.ts:705](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L705)
 
-___
+---
 
 #### sendIntent
 
@@ -1258,9 +1246,9 @@ use `sendFlow` instead
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `intentId` | `string` | the intent to trigger. The id is the name under the application's _Intents_. |
+| Name       | Type                  | Description                                                                                                                               |
+| :--------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `intentId` | `string`              | the intent to trigger. The id is the name under the application's _Intents_.                                                              |
 | `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1271,7 +1259,7 @@ use `sendFlow` instead
 
 [index.ts:713](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L713)
 
-___
+---
 
 #### sendContext
 
@@ -1285,8 +1273,8 @@ Send context without sending a message
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type                  | Description                                                                                                                               |
+| :-------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | `context` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
@@ -1297,7 +1285,7 @@ Send context without sending a message
 
 [index.ts:719](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L719)
 
-___
+---
 
 #### getVoiceCredentials
 
@@ -1311,8 +1299,8 @@ Obtain Voice credentials to run the experience in voice.
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name       | Type                  |
+| :--------- | :-------------------- |
 | `context?` | [`Context`](#context) |
 
 ###### Returns
@@ -1323,7 +1311,7 @@ Obtain Voice credentials to run the experience in voice.
 
 [index.ts:726](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L726)
 
-___
+---
 
 #### sendStructured
 
@@ -1337,10 +1325,10 @@ Send a combination of choice, slots, and intent in one request.
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `request` | [`StructuredRequest`](#interfacesstructuredrequestmd) |  |
-| `context?` | [`Context`](#context) | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
+| Name       | Type                                                  | Description                                                                                                                               |
+| :--------- | :---------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `request`  | [`StructuredRequest`](#interfacesstructuredrequestmd) |                                                                                                                                           |
+| `context?` | [`Context`](#context)                                 | [Context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) for usage later in the intent. |
 
 ###### Returns
 
@@ -1350,7 +1338,7 @@ Send a combination of choice, slots, and intent in one request.
 
 [index.ts:733](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L733)
 
-___
+---
 
 #### subscribe
 
@@ -1364,8 +1352,8 @@ Subscribe a callback to the conversation. On subscribe, the subscriber will rece
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name         | Type                        | Description               |
+| :----------- | :-------------------------- | :------------------------ |
 | `subscriber` | [`Subscriber`](#subscriber) | The callback to subscribe |
 
 ###### Returns
@@ -1382,7 +1370,7 @@ Subscribe a callback to the conversation. On subscribe, the subscriber will rece
 
 [index.ts:738](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L738)
 
-___
+---
 
 #### unsubscribe
 
@@ -1396,8 +1384,8 @@ Unsubscribe a callback from the conversation.
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name         | Type                        | Description                 |
+| :----------- | :-------------------------- | :-------------------------- |
 | `subscriber` | [`Subscriber`](#subscriber) | The callback to unsubscribe |
 
 ###### Returns
@@ -1408,7 +1396,7 @@ Unsubscribe a callback from the conversation.
 
 [index.ts:743](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L743)
 
-___
+---
 
 #### unsubscribeAll
 
@@ -1428,7 +1416,7 @@ Unsubscribe all callback from the conversation.
 
 [index.ts:747](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L747)
 
-___
+---
 
 #### currentConversationId
 
@@ -1448,7 +1436,7 @@ Get the current conversation ID if it's set, or undefined if there is no convers
 
 [index.ts:751](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L751)
 
-___
+---
 
 #### currentLanguageCode
 
@@ -1468,7 +1456,7 @@ Get the current language code
 
 [index.ts:755](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L755)
 
-___
+---
 
 #### setLanguageCode
 
@@ -1482,8 +1470,8 @@ Set the language code
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name           | Type     |
+| :------------- | :------- |
 | `languageCode` | `string` |
 
 ###### Returns
@@ -1494,11 +1482,11 @@ Set the language code
 
 [index.ts:759](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L759)
 
-___
+---
 
 #### reset
 
-• **reset**: (`options?`: \{ `clearResponses?`: `boolean`  }) => `void`
+• **reset**: (`options?`: \{ `clearResponses?`: `boolean` }) => `void`
 
 Forces a new conversation. If `clearResponses` is set to true, will also clear historical responses passed to subscribers.
 Retains all existing subscribers.
@@ -1509,9 +1497,9 @@ Retains all existing subscribers.
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `options?` | `Object` | - |
+| Name                      | Type      | Description                                                            |
+| :------------------------ | :-------- | :--------------------------------------------------------------------- |
+| `options?`                | `Object`  | -                                                                      |
 | `options.clearResponses?` | `boolean` | If set to true, will clear historical responses passed to subscribers. |
 
 ###### Returns
@@ -1522,7 +1510,7 @@ Retains all existing subscribers.
 
 [index.ts:764](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L764)
 
-___
+---
 
 #### destroy
 
@@ -1542,7 +1530,7 @@ Removes all subscribers and, if using websockets, closes the connection.
 
 [index.ts:773](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L773)
 
-___
+---
 
 #### setBotRequestOverride
 
@@ -1560,8 +1548,8 @@ use `setRequestOverride` instead
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name       | Type                                                 |
+| :--------- | :--------------------------------------------------- |
 | `override` | `undefined` \| [`RequestOverride`](#requestoverride) |
 
 ###### Returns
@@ -1572,7 +1560,7 @@ use `setRequestOverride` instead
 
 [index.ts:778](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L778)
 
-___
+---
 
 #### setRequestOverride
 
@@ -1586,8 +1574,8 @@ Optional [RequestOverride](#requestoverride) function used to bypass the bot req
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name       | Type                                                 |
+| :--------- | :--------------------------------------------------- |
 | `override` | `undefined` \| [`RequestOverride`](#requestoverride) |
 
 ###### Returns
@@ -1598,11 +1586,11 @@ Optional [RequestOverride](#requestoverride) function used to bypass the bot req
 
 [index.ts:782](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L782)
 
-___
+---
 
 #### addEventListener
 
-• **addEventListener**: (`event`: ``"voicePlusCommand"``, `handler`: (`payload`: `any`) => `void`) => `void`
+• **addEventListener**: (`event`: `"voicePlusCommand"`, `handler`: (`payload`: `any`) => `void`) => `void`
 
 Add a listener to one of the handler's custom events
 
@@ -1612,9 +1600,9 @@ Add a listener to one of the handler's custom events
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `event` | ``"voicePlusCommand"`` |
+| Name      | Type                         |
+| :-------- | :--------------------------- |
+| `event`   | `"voicePlusCommand"`         |
 | `handler` | (`payload`: `any`) => `void` |
 
 ###### Returns
@@ -1625,11 +1613,11 @@ Add a listener to one of the handler's custom events
 
 [index.ts:786](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L786)
 
-___
+---
 
 #### removeEventListener
 
-• **removeEventListener**: (`event`: ``"voicePlusCommand"``, `handler`: (`payload`: `any`) => `void`) => `void`
+• **removeEventListener**: (`event`: `"voicePlusCommand"`, `handler`: (`payload`: `any`) => `void`) => `void`
 
 Remove a listener to one of the handler's custom events
 
@@ -1639,9 +1627,9 @@ Remove a listener to one of the handler's custom events
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `event` | ``"voicePlusCommand"`` |
+| Name      | Type                         |
+| :-------- | :--------------------------- |
+| `event`   | `"voicePlusCommand"`         |
 | `handler` | (`payload`: `any`) => `void` |
 
 ###### Returns
@@ -1652,7 +1640,7 @@ Remove a listener to one of the handler's custom events
 
 [index.ts:793](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L793)
 
-___
+---
 
 #### sendVoicePlusContext
 
@@ -1666,8 +1654,8 @@ Send voicePlus message
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type  |
+| :-------- | :---- |
 | `context` | `any` |
 
 ###### Returns
@@ -1677,7 +1665,6 @@ Send voicePlus message
 ##### Defined in
 
 [index.ts:800](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L800)
-
 
 <a name="interfaceseventhandlersmd"></a>
 
@@ -1699,8 +1686,8 @@ Voice+ command event handler
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type  |
+| :-------- | :---- |
 | `payload` | `any` |
 
 ###### Returns
@@ -1710,7 +1697,6 @@ Voice+ command event handler
 ##### Defined in
 
 [index.ts:656](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L656)
-
 
 <a name="interfacesfailuremessagemd"></a>
 
@@ -1722,7 +1708,7 @@ A failure message is received when the NLX api is unreachable, or sends an unpar
 
 #### type
 
-• **type**: ``"failure"``
+• **type**: `"failure"`
 
 The type of the response is `"bot"` for bot and `"user"` for user.
 
@@ -1730,7 +1716,7 @@ The type of the response is `"bot"` for bot and `"user"` for user.
 
 [index.ts:332](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L332)
 
-___
+---
 
 #### payload
 
@@ -1740,15 +1726,15 @@ The payload only includes an error message.
 
 ##### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name   | Type     | Description                                                                                                |
+| :----- | :------- | :--------------------------------------------------------------------------------------------------------- |
 | `text` | `string` | The error message is either the default, or the `failureMessage` set in the [Config](#interfacesconfigmd). |
 
 ##### Defined in
 
 [index.ts:336](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L336)
 
-___
+---
 
 #### receivedAt
 
@@ -1759,7 +1745,6 @@ When the failure occurred.
 ##### Defined in
 
 [index.ts:345](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L345)
-
 
 <a name="interfacesknowledgebaseresponsesourcemd"></a>
 
@@ -1779,7 +1764,7 @@ File name
 
 [index.ts:161](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L161)
 
-___
+---
 
 #### pageNumber
 
@@ -1791,7 +1776,7 @@ Page number
 
 [index.ts:165](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L165)
 
-___
+---
 
 #### content
 
@@ -1803,7 +1788,7 @@ Content
 
 [index.ts:169](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L169)
 
-___
+---
 
 #### metadata
 
@@ -1815,7 +1800,7 @@ Metadata
 
 [index.ts:173](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L173)
 
-___
+---
 
 #### presignedUrl
 
@@ -1826,7 +1811,6 @@ Presigned URL for direct retrieval
 ##### Defined in
 
 [index.ts:177](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L177)
-
 
 <a name="interfacesslotvaluemd"></a>
 
@@ -1848,7 +1832,7 @@ The attached slot's name
 
 [index.ts:29](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L29)
 
-___
+---
 
 #### value
 
@@ -1860,7 +1844,6 @@ for custom slots, this can optionally be the value's ID.
 ##### Defined in
 
 [index.ts:34](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L34)
-
 
 <a name="interfacesstructuredrequestmd"></a>
 
@@ -1881,7 +1864,7 @@ The `choiceId` is in the [BotResponse](#interfacesbotresponsemd)'s `.payload.mes
 
 [index.ts:468](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L468)
 
-___
+---
 
 #### nodeId
 
@@ -1894,7 +1877,7 @@ The `nodeId` can be found in the corresponding [BotMessage](#interfacesbotmessag
 
 [index.ts:473](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L473)
 
-___
+---
 
 #### intentId
 
@@ -1910,7 +1893,7 @@ use `flowId` instead.
 
 [index.ts:478](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L478)
 
-___
+---
 
 #### flowId
 
@@ -1922,7 +1905,7 @@ The flow to trigger. The `flowId` is the name under the application's _Flows_.
 
 [index.ts:482](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L482)
 
-___
+---
 
 #### slots
 
@@ -1934,7 +1917,7 @@ The slots to populate
 
 [index.ts:486](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L486)
 
-___
+---
 
 #### uploadIds
 
@@ -1946,7 +1929,7 @@ Upload ID
 
 [index.ts:490](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L490)
 
-___
+---
 
 #### utterance
 
@@ -1957,7 +1940,6 @@ Upload utterance
 ##### Defined in
 
 [index.ts:494](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L494)
-
 
 <a name="interfacesuploadurlmd"></a>
 
@@ -1977,7 +1959,7 @@ The URL of the upload
 
 [index.ts:230](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L230)
 
-___
+---
 
 #### uploadId
 
@@ -1989,7 +1971,6 @@ The ID of the upload
 
 [index.ts:234](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L234)
 
-
 <a name="interfacesuserresponsemd"></a>
 
 ## Interface: UserResponse
@@ -1997,6 +1978,7 @@ The ID of the upload
 A message from the user
 
 See also:
+
 - [BotResponse](#interfacesbotresponsemd)
 - [FailureMessage](#interfacesfailuremessagemd)
 - [Response](#response)
@@ -2005,7 +1987,7 @@ See also:
 
 #### type
 
-• **type**: ``"user"``
+• **type**: `"user"`
 
 The type of the response is `"bot"` for bot and `"user"` for user, and "failure" for failure.
 
@@ -2013,7 +1995,7 @@ The type of the response is `"bot"` for bot and `"user"` for user, and "failure"
 
 [index.ts:268](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L268)
 
-___
+---
 
 #### receivedAt
 
@@ -2025,7 +2007,7 @@ When the response was received
 
 [index.ts:272](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L272)
 
-___
+---
 
 #### payload
 
@@ -2036,7 +2018,6 @@ The payload of the response
 ##### Defined in
 
 [index.ts:276](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L276)
-
 
 <a name="interfacesvoicecredentialsmd"></a>
 
@@ -2056,7 +2037,7 @@ Voice Connection URL
 
 [index.ts:566](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L566)
 
-___
+---
 
 #### roomName
 
@@ -2068,7 +2049,7 @@ Voice room name
 
 [index.ts:570](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L570)
 
-___
+---
 
 #### token
 
@@ -2080,7 +2061,7 @@ Voice token
 
 [index.ts:574](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L574)
 
-___
+---
 
 #### participantName
 
@@ -2091,7 +2072,6 @@ Voice participant name
 ##### Defined in
 
 [index.ts:578](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-core/src/index.ts#L578)
-
 
 <a name="interfacesvoiceplusmessagemd"></a>
 

--- a/packages/website/src/content/preact-api-reference.md
+++ b/packages/website/src/content/preact-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/chat-preact
@@ -24,8 +23,8 @@ custom chat widgets for web and mobile.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name     | Type     | Description                               |
+| :------- | :------- | :---------------------------------------- |
 | `config` | `Config` | The configuration object for the chatbot. |
 
 #### Returns
@@ -38,12 +37,9 @@ the hook object containing the chat state and methods.
 
 [index.ts:53](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L53)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfaceschathookmd"></a>
 
@@ -65,7 +61,7 @@ handled by the hook automatically.
 
 [index.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L22)
 
-___
+---
 
 #### inputValue
 
@@ -79,7 +75,7 @@ Using this field is optional and you can hold input state separately.
 
 [index.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L28)
 
-___
+---
 
 #### setInputValue
 
@@ -93,8 +89,8 @@ Modify the value of the chat input field.
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name  | Type     | Description                       |
+| :---- | :------- | :-------------------------------- |
 | `val` | `string` | The new value of the input field. |
 
 ###### Returns
@@ -105,7 +101,7 @@ Modify the value of the chat input field.
 
 [index.ts:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L33)
 
-___
+---
 
 #### responses
 
@@ -119,7 +115,7 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 [index.ts:39](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L39)
 
-___
+---
 
 #### waiting
 

--- a/packages/website/src/content/preact-api-reference.md
+++ b/packages/website/src/content/preact-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/chat-preact
@@ -23,8 +24,8 @@ custom chat widgets for web and mobile.
 
 #### Parameters
 
-| Name     | Type     | Description                               |
-| :------- | :------- | :---------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `config` | `Config` | The configuration object for the chatbot. |
 
 #### Returns
@@ -35,11 +36,14 @@ the hook object containing the chat state and methods.
 
 #### Defined in
 
-[index.ts:53](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-preact/src/index.ts#L53)
+[index.ts:53](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L53)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
 
 <a name="interfaceschathookmd"></a>
 
@@ -59,9 +63,9 @@ handled by the hook automatically.
 
 ##### Defined in
 
-[index.ts:22](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-preact/src/index.ts#L22)
+[index.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L22)
 
----
+___
 
 #### inputValue
 
@@ -73,9 +77,9 @@ Using this field is optional and you can hold input state separately.
 
 ##### Defined in
 
-[index.ts:28](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-preact/src/index.ts#L28)
+[index.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L28)
 
----
+___
 
 #### setInputValue
 
@@ -89,8 +93,8 @@ Modify the value of the chat input field.
 
 ###### Parameters
 
-| Name  | Type     | Description                       |
-| :---- | :------- | :-------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `val` | `string` | The new value of the input field. |
 
 ###### Returns
@@ -99,9 +103,9 @@ Modify the value of the chat input field.
 
 ##### Defined in
 
-[index.ts:33](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-preact/src/index.ts#L33)
+[index.ts:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L33)
 
----
+___
 
 #### responses
 
@@ -113,9 +117,9 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 ##### Defined in
 
-[index.ts:39](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-preact/src/index.ts#L39)
+[index.ts:39](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L39)
 
----
+___
 
 #### waiting
 
@@ -126,4 +130,4 @@ bubble with loading dots.
 
 ##### Defined in
 
-[index.ts:44](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-preact/src/index.ts#L44)
+[index.ts:44](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-preact/src/index.ts#L44)

--- a/packages/website/src/content/react-api-reference.md
+++ b/packages/website/src/content/react-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/chat-react
@@ -23,8 +24,8 @@ used to create fully custom chat widgets for web and mobile.
 
 #### Parameters
 
-| Name     | Type     | Description                               |
-| :------- | :------- | :---------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `config` | `Config` | The configuration object for the chatbot. |
 
 #### Returns
@@ -35,11 +36,14 @@ the hook object containing the chat state and methods.
 
 #### Defined in
 
-[index.ts:53](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-react/src/index.ts#L53)
+[index.ts:53](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L53)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
 
 <a name="interfaceschathookmd"></a>
 
@@ -59,9 +63,9 @@ handled by the hook automatically.
 
 ##### Defined in
 
-[index.ts:22](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-react/src/index.ts#L22)
+[index.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L22)
 
----
+___
 
 #### inputValue
 
@@ -73,9 +77,9 @@ Using this field is optional and you can hold input state separately.
 
 ##### Defined in
 
-[index.ts:28](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-react/src/index.ts#L28)
+[index.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L28)
 
----
+___
 
 #### setInputValue
 
@@ -89,8 +93,8 @@ Modify the value of the chat input field.
 
 ###### Parameters
 
-| Name  | Type     | Description                       |
-| :---- | :------- | :-------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `val` | `string` | The new value of the input field. |
 
 ###### Returns
@@ -99,9 +103,9 @@ Modify the value of the chat input field.
 
 ##### Defined in
 
-[index.ts:33](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-react/src/index.ts#L33)
+[index.ts:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L33)
 
----
+___
 
 #### responses
 
@@ -113,9 +117,9 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 ##### Defined in
 
-[index.ts:39](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-react/src/index.ts#L39)
+[index.ts:39](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L39)
 
----
+___
 
 #### waiting
 
@@ -126,4 +130,4 @@ bubble with loading dots.
 
 ##### Defined in
 
-[index.ts:44](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-react/src/index.ts#L44)
+[index.ts:44](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L44)

--- a/packages/website/src/content/react-api-reference.md
+++ b/packages/website/src/content/react-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/chat-react
@@ -24,8 +23,8 @@ used to create fully custom chat widgets for web and mobile.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name     | Type     | Description                               |
+| :------- | :------- | :---------------------------------------- |
 | `config` | `Config` | The configuration object for the chatbot. |
 
 #### Returns
@@ -38,12 +37,9 @@ the hook object containing the chat state and methods.
 
 [index.ts:53](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L53)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfaceschathookmd"></a>
 
@@ -65,7 +61,7 @@ handled by the hook automatically.
 
 [index.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L22)
 
-___
+---
 
 #### inputValue
 
@@ -79,7 +75,7 @@ Using this field is optional and you can hold input state separately.
 
 [index.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L28)
 
-___
+---
 
 #### setInputValue
 
@@ -93,8 +89,8 @@ Modify the value of the chat input field.
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name  | Type     | Description                       |
+| :---- | :------- | :-------------------------------- |
 | `val` | `string` | The new value of the input field. |
 
 ###### Returns
@@ -105,7 +101,7 @@ Modify the value of the chat input field.
 
 [index.ts:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L33)
 
-___
+---
 
 #### responses
 
@@ -119,7 +115,7 @@ Please refer to [the type definitions](https://developers.nlx.ai/headless-api-re
 
 [index.ts:39](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-react/src/index.ts#L39)
 
-___
+---
 
 #### waiting
 

--- a/packages/website/src/content/script-manager-api-reference.md
+++ b/packages/website/src/content/script-manager-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/voice-plus-web
@@ -11,8 +12,6 @@
 - [SimpleHandlerArg](#interfacessimplehandlerargmd)
 - [ButtonConfig](#interfacesbuttonconfigmd)
 - [UiConfig](#interfacesuiconfigmd)
-- [InteractiveElementInfo](#interfacesinteractiveelementinfomd)
-- [PageForms](#interfacespageformsmd)
 - [RunProps](#interfacesrunpropsmd)
 - [RunOutput](#interfacesrunoutputmd)
 - [SerializedRegex](#interfacesserializedregexmd)
@@ -29,39 +28,27 @@ Renames and re-exports [run](#run)
 
 ### HandlerArg
 
-Ƭ **HandlerArg**: [`SimpleHandlerArg`](#interfacessimplehandlerargmd) & \{ `triggeredSteps`: [`TriggeredStep`](#interfacestriggeredstepmd)[] }
+Ƭ **HandlerArg**: [`SimpleHandlerArg`](#interfacessimplehandlerargmd) & \{ `triggeredSteps`: [`TriggeredStep`](#interfacestriggeredstepmd)[]  }
 
 Used for some more advanced callbacks
 
 #### Defined in
 
-[voice-plus-web/src/configuration.ts:50](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L50)
+[voice-plus-web/src/configuration.ts:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L50)
 
----
-
-### AccessibilityInformation
-
-Ƭ **AccessibilityInformation**: `Record`\<`string`, `any`\>
-
-Accessibility information
-
-#### Defined in
-
-[voice-plus-web/src/context.ts:9](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/context.ts#L9)
-
----
+___
 
 ### Method
 
-Ƭ **Method**: `"AltText"` \| `"DisplayValue"` \| `"LabelText"` \| `"PlaceholderText"` \| `"Role"` \| `"TestId"` \| `"Text"` \| `"Title"` \| `"QuerySelector"`
+Ƭ **Method**: ``"AltText"`` \| ``"DisplayValue"`` \| ``"LabelText"`` \| ``"PlaceholderText"`` \| ``"Role"`` \| ``"TestId"`` \| ``"Text"`` \| ``"Title"`` \| ``"QuerySelector"``
 
 Matching method
 
 #### Defined in
 
-[voice-plus-web/src/queries.ts:10](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L10)
+[voice-plus-web/src/queries.ts:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L10)
 
----
+___
 
 ### Triggers
 
@@ -71,9 +58,9 @@ A record of triggers
 
 #### Defined in
 
-[voice-plus-web/src/trigger.ts:36](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L36)
+[voice-plus-web/src/trigger.ts:36](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L36)
 
----
+___
 
 ### StepId
 
@@ -83,7 +70,7 @@ Step ID
 
 #### Defined in
 
-[voice-plus-web/src/trigger.ts:65](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L65)
+[voice-plus-web/src/trigger.ts:65](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L65)
 
 ## Variables
 
@@ -95,35 +82,17 @@ Icon URL's
 
 #### Type declaration
 
-| Name           | Type     | Description        |
-| :------------- | :------- | :----------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `supportAgent` | `string` | Support agent icon |
-| `callEnd`      | `string` | Call end icon      |
-| `multimodal`   | `string` | Multimodal icon    |
+| `callEnd` | `string` | Call end icon |
+| `multimodal` | `string` | Multimodal icon |
 
 #### Defined in
 
-[voice-plus-web/src/ui/components/icons.tsx:12](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/ui/components/icons.tsx#L12)
+[voice-plus-web/src/ui/components/icons.tsx:12](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/ui/components/icons.tsx#L12)
 
 ## Functions
-
-### analyzePageForms
-
-▸ **analyzePageForms**(): [`PageForms`](#interfacespageformsmd)
-
-Analyze page forms
-
-#### Returns
-
-[`PageForms`](#interfacespageformsmd)
-
-pageForms
-
-#### Defined in
-
-[voice-plus-web/src/context.ts:66](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/context.ts#L66)
-
----
 
 ### run
 
@@ -133,8 +102,8 @@ Run the Voice+ script
 
 #### Parameters
 
-| Name    | Type                                | Description                  |
-| :------ | :---------------------------------- | :--------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `props` | [`RunProps`](#interfacesrunpropsmd) | The run configuration object |
 
 #### Returns
@@ -145,11 +114,14 @@ an promise of an object containing a teardown function and the Voice+ client.
 
 #### Defined in
 
-[voice-plus-web/src/index.ts:90](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L90)
+[voice-plus-web/src/index.ts:85](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L85)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
 
 <a name="interfacesbuttonconfigmd"></a>
 
@@ -167,9 +139,9 @@ Button label
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:62](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L62)
+[voice-plus-web/src/configuration.ts:62](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L62)
 
----
+___
 
 #### confirmation
 
@@ -179,9 +151,9 @@ Button confirmation: if present, the button click handler only triggers after th
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:66](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L66)
+[voice-plus-web/src/configuration.ts:66](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L66)
 
----
+___
 
 #### iconUrl
 
@@ -191,9 +163,9 @@ Icon URL
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:70](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L70)
+[voice-plus-web/src/configuration.ts:70](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L70)
 
----
+___
 
 #### onClick
 
@@ -207,8 +179,8 @@ Click handler
 
 ###### Parameters
 
-| Name     | Type                        |
-| :------- | :-------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `config` | [`HandlerArg`](#handlerarg) |
 
 ###### Returns
@@ -217,7 +189,8 @@ Click handler
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:74](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L74)
+[voice-plus-web/src/configuration.ts:74](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L74)
+
 
 <a name="interfacesencodedquerymd"></a>
 
@@ -235,9 +208,9 @@ Query name
 
 ##### Defined in
 
-[voice-plus-web/src/queries.ts:60](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L60)
+[voice-plus-web/src/queries.ts:60](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L60)
 
----
+___
 
 #### target
 
@@ -247,85 +220,32 @@ Query target
 
 ##### Defined in
 
-[voice-plus-web/src/queries.ts:64](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L64)
+[voice-plus-web/src/queries.ts:64](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L64)
 
----
+___
 
 #### options
 
-• **options**: `null` \| `Record`\<`string`, `boolean` \| [`SerializedRegex`](#interfacesserializedregexmd)\>
+• **options**: ``null`` \| `Record`\<`string`, `boolean` \| [`SerializedRegex`](#interfacesserializedregexmd)\>
 
 Query options
 
 ##### Defined in
 
-[voice-plus-web/src/queries.ts:68](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L68)
+[voice-plus-web/src/queries.ts:68](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L68)
 
----
+___
 
 #### parent
 
-• **parent**: `null` \| [`EncodedQuery`](#interfacesencodedquerymd)
+• **parent**: ``null`` \| [`EncodedQuery`](#interfacesencodedquerymd)
 
 Query parent
 
 ##### Defined in
 
-[voice-plus-web/src/queries.ts:72](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L72)
+[voice-plus-web/src/queries.ts:72](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L72)
 
-<a name="interfacesinteractiveelementinfomd"></a>
-
-## Interface: InteractiveElementInfo
-
-Accessibility information with ID
-
-### Hierarchy
-
-- [`AccessibilityInformation`](#accessibilityinformation)
-
-  ↳ **`InteractiveElementInfo`**
-
-### Properties
-
-#### id
-
-• **id**: `string`
-
-Form element ID (assigned by the analysis logic, not necessarily equal to the DOM ID)
-
-##### Defined in
-
-[voice-plus-web/src/context.ts:18](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/context.ts#L18)
-
-<a name="interfacespageformsmd"></a>
-
-## Interface: PageForms
-
-Page forms with elements
-
-### Properties
-
-#### context
-
-• **context**: [`InteractiveElementInfo`](#interfacesinteractiveelementinfomd)[]
-
-Page context
-
-##### Defined in
-
-[voice-plus-web/src/context.ts:28](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/context.ts#L28)
-
----
-
-#### formElements
-
-• **formElements**: `Record`\<`string`, `Element`\>
-
-Form element references
-
-##### Defined in
-
-[voice-plus-web/src/context.ts:32](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/context.ts#L32)
 
 <a name="interfacesrunoutputmd"></a>
 
@@ -351,9 +271,9 @@ Stop running the journey, removing all event listeners
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:78](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L78)
+[voice-plus-web/src/index.ts:73](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L73)
 
----
+___
 
 #### client
 
@@ -363,7 +283,8 @@ The regular Voice+ SDK client
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:82](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L82)
+[voice-plus-web/src/index.ts:77](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L77)
+
 
 <a name="interfacesrunpropsmd"></a>
 
@@ -381,9 +302,9 @@ The regular Voice+ configuration
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:51](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L51)
+[voice-plus-web/src/index.ts:46](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L46)
 
----
+___
 
 #### ui
 
@@ -393,9 +314,9 @@ UI configuration
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:55](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L55)
+[voice-plus-web/src/index.ts:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L50)
 
----
+___
 
 #### triggers
 
@@ -406,9 +327,9 @@ If triggers are not provided, they will be fetched from the CDN.
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:60](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L60)
+[voice-plus-web/src/index.ts:55](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L55)
 
----
+___
 
 #### onDigression
 
@@ -422,8 +343,8 @@ Digression detection callback
 
 ###### Parameters
 
-| Name     | Type     |
-| :------- | :------- |
+| Name | Type |
+| :------ | :------ |
 | `client` | `Client` |
 
 ###### Returns
@@ -432,9 +353,9 @@ Digression detection callback
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:64](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L64)
+[voice-plus-web/src/index.ts:59](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L59)
 
----
+___
 
 #### onStep
 
@@ -448,8 +369,8 @@ Runs when a step is triggered, used primarily for debugging
 
 ###### Parameters
 
-| Name     | Type     |
-| :------- | :------- |
+| Name | Type |
+| :------ | :------ |
 | `stepId` | `string` |
 
 ###### Returns
@@ -458,7 +379,8 @@ Runs when a step is triggered, used primarily for debugging
 
 ##### Defined in
 
-[voice-plus-web/src/index.ts:68](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/index.ts#L68)
+[voice-plus-web/src/index.ts:63](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L63)
+
 
 <a name="interfacesserializedregexmd"></a>
 
@@ -476,9 +398,9 @@ Regex body
 
 ##### Defined in
 
-[voice-plus-web/src/queries.ts:46](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L46)
+[voice-plus-web/src/queries.ts:46](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L46)
 
----
+___
 
 #### flags
 
@@ -488,7 +410,8 @@ Regex flags
 
 ##### Defined in
 
-[voice-plus-web/src/queries.ts:50](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/queries.ts#L50)
+[voice-plus-web/src/queries.ts:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L50)
+
 
 <a name="interfacessimplehandlerargmd"></a>
 
@@ -510,10 +433,10 @@ A function to send steps to NLX.
 
 ###### Parameters
 
-| Name       | Type       |
-| :--------- | :--------- |
-| `step`     | `StepInfo` |
-| `context?` | `Context`  |
+| Name | Type |
+| :------ | :------ |
+| `step` | `StepInfo` |
+| `context?` | `Context` |
 
 ###### Returns
 
@@ -521,7 +444,8 @@ A function to send steps to NLX.
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:46](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L46)
+[voice-plus-web/src/configuration.ts:46](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L46)
+
 
 <a name="interfacesthememd"></a>
 
@@ -539,9 +463,9 @@ UI colors
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:28](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L28)
+[voice-plus-web/src/configuration.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L28)
 
----
+___
 
 #### fontFamily
 
@@ -551,7 +475,8 @@ Font family
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:32](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L32)
+[voice-plus-web/src/configuration.ts:32](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L32)
+
 
 <a name="interfacesthemecolorsmd"></a>
 
@@ -569,9 +494,9 @@ Primary color
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:10](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L10)
+[voice-plus-web/src/configuration.ts:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L10)
 
----
+___
 
 #### primaryHover
 
@@ -581,9 +506,9 @@ Primary color on hover
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:14](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L14)
+[voice-plus-web/src/configuration.ts:14](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L14)
 
----
+___
 
 #### highlight
 
@@ -593,7 +518,8 @@ Color for trigger highlights
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:18](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L18)
+[voice-plus-web/src/configuration.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L18)
+
 
 <a name="interfacestriggermd"></a>
 
@@ -605,15 +531,15 @@ A single trigger
 
 #### event
 
-• **event**: `"click"` \| `"pageLoad"` \| `"appear"` \| `"enterViewport"`
+• **event**: ``"click"`` \| ``"pageLoad"`` \| ``"appear"`` \| ``"enterViewport"``
 
 Event
 
 ##### Defined in
 
-[voice-plus-web/src/trigger.ts:14](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L14)
+[voice-plus-web/src/trigger.ts:14](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L14)
 
----
+___
 
 #### query
 
@@ -623,9 +549,9 @@ A query identifying the element
 
 ##### Defined in
 
-[voice-plus-web/src/trigger.ts:18](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L18)
+[voice-plus-web/src/trigger.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L18)
 
----
+___
 
 #### once
 
@@ -635,9 +561,9 @@ A flag specifying whether the trigger should only fire a single time
 
 ##### Defined in
 
-[voice-plus-web/src/trigger.ts:22](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L22)
+[voice-plus-web/src/trigger.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L22)
 
----
+___
 
 #### highlight
 
@@ -647,9 +573,9 @@ A flag specifying whether the trigger should highlight. Only applicable to click
 
 ##### Defined in
 
-[voice-plus-web/src/trigger.ts:26](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L26)
+[voice-plus-web/src/trigger.ts:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L26)
 
----
+___
 
 #### urlCondition
 
@@ -659,7 +585,8 @@ URL condition
 
 ##### Defined in
 
-[voice-plus-web/src/trigger.ts:30](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/trigger.ts#L30)
+[voice-plus-web/src/trigger.ts:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L30)
+
 
 <a name="interfacestriggeredstepmd"></a>
 
@@ -677,9 +604,9 @@ step id
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:38](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L38)
+[voice-plus-web/src/configuration.ts:38](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L38)
 
----
+___
 
 #### url
 
@@ -689,7 +616,8 @@ the URL of the page it triggered on
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:40](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L40)
+[voice-plus-web/src/configuration.ts:40](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L40)
+
 
 <a name="interfacesuiconfigmd"></a>
 
@@ -707,9 +635,9 @@ Drawer title
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:84](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L84)
+[voice-plus-web/src/configuration.ts:84](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L84)
 
----
+___
 
 #### subtitle
 
@@ -719,9 +647,9 @@ Drawer subtitle
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:88](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L88)
+[voice-plus-web/src/configuration.ts:88](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L88)
 
----
+___
 
 #### highlights
 
@@ -731,9 +659,9 @@ Render highlights
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:92](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L92)
+[voice-plus-web/src/configuration.ts:92](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L92)
 
----
+___
 
 #### iconUrl
 
@@ -743,9 +671,9 @@ URL for the button icon
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:101](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L101)
+[voice-plus-web/src/configuration.ts:101](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L101)
 
----
+___
 
 #### theme
 
@@ -755,9 +683,9 @@ UI theme
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:105](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L105)
+[voice-plus-web/src/configuration.ts:105](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L105)
 
----
+___
 
 #### onEscalation
 
@@ -771,8 +699,8 @@ Escalation handler
 
 ###### Parameters
 
-| Name     | Type                                                |
-| :------- | :-------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `config` | [`SimpleHandlerArg`](#interfacessimplehandlerargmd) |
 
 ###### Returns
@@ -781,9 +709,9 @@ Escalation handler
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:109](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L109)
+[voice-plus-web/src/configuration.ts:109](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L109)
 
----
+___
 
 #### escalationButtonLabel
 
@@ -793,9 +721,9 @@ Escalation button label
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:113](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L113)
+[voice-plus-web/src/configuration.ts:113](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L113)
 
----
+___
 
 #### escalationConfirmation
 
@@ -805,9 +733,9 @@ Escalation confirmation
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:117](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L117)
+[voice-plus-web/src/configuration.ts:117](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L117)
 
----
+___
 
 #### onEnd
 
@@ -821,8 +749,8 @@ End handler
 
 ###### Parameters
 
-| Name     | Type                                                |
-| :------- | :-------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `config` | [`SimpleHandlerArg`](#interfacessimplehandlerargmd) |
 
 ###### Returns
@@ -831,9 +759,9 @@ End handler
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:121](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L121)
+[voice-plus-web/src/configuration.ts:121](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L121)
 
----
+___
 
 #### endButtonLabel
 
@@ -843,9 +771,9 @@ End button label
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:125](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L125)
+[voice-plus-web/src/configuration.ts:125](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L125)
 
----
+___
 
 #### endConfirmation
 
@@ -855,9 +783,9 @@ End confirmation
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:129](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L129)
+[voice-plus-web/src/configuration.ts:129](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L129)
 
----
+___
 
 #### onPreviousStep
 
@@ -871,8 +799,8 @@ On previous step
 
 ###### Parameters
 
-| Name     | Type                        |
-| :------- | :-------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `config` | [`HandlerArg`](#handlerarg) |
 
 ###### Returns
@@ -881,9 +809,9 @@ On previous step
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:133](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L133)
+[voice-plus-web/src/configuration.ts:133](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L133)
 
----
+___
 
 #### previousStepButtonLabel
 
@@ -893,9 +821,9 @@ Previous step button label
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:137](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L137)
+[voice-plus-web/src/configuration.ts:137](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L137)
 
----
+___
 
 #### buttons
 
@@ -905,9 +833,9 @@ Custom buttons
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:141](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L141)
+[voice-plus-web/src/configuration.ts:141](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L141)
 
----
+___
 
 #### nudgeContent
 
@@ -918,9 +846,9 @@ it will be shown only if the user never interacts with the overlay pin, after `t
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:146](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L146)
+[voice-plus-web/src/configuration.ts:146](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L146)
 
----
+___
 
 #### nudgeShowAfterMs
 
@@ -930,9 +858,9 @@ Show nudge tooltip after this many milliseconds
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:150](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L150)
+[voice-plus-web/src/configuration.ts:150](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L150)
 
----
+___
 
 #### nudgeHideAfterMs
 
@@ -942,7 +870,8 @@ Hide nudge tooltip after it's been shown for this many milliseconds
 
 ##### Defined in
 
-[voice-plus-web/src/configuration.ts:154](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/configuration.ts#L154)
+[voice-plus-web/src/configuration.ts:154](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L154)
+
 
 <a name="interfacesurlconditionmd"></a>
 
@@ -954,15 +883,15 @@ URL match condition
 
 #### operator
 
-• **operator**: `"contains"` \| `"matches_regex"` \| `"smart_match"`
+• **operator**: ``"contains"`` \| ``"matches_regex"`` \| ``"smart_match"``
 
 Condition operator
 
 ##### Defined in
 
-[voice-plus-web/src/UrlCondition.ts:8](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/UrlCondition.ts#L8)
+[voice-plus-web/src/UrlCondition.ts:8](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/UrlCondition.ts#L8)
 
----
+___
 
 #### value
 
@@ -972,4 +901,4 @@ Condition value
 
 ##### Defined in
 
-[voice-plus-web/src/UrlCondition.ts:12](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-web/src/UrlCondition.ts#L12)
+[voice-plus-web/src/UrlCondition.ts:12](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/UrlCondition.ts#L12)

--- a/packages/website/src/content/script-manager-api-reference.md
+++ b/packages/website/src/content/script-manager-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/voice-plus-web
@@ -28,7 +27,7 @@ Renames and re-exports [run](#run)
 
 ### HandlerArg
 
-Ƭ **HandlerArg**: [`SimpleHandlerArg`](#interfacessimplehandlerargmd) & \{ `triggeredSteps`: [`TriggeredStep`](#interfacestriggeredstepmd)[]  }
+Ƭ **HandlerArg**: [`SimpleHandlerArg`](#interfacessimplehandlerargmd) & \{ `triggeredSteps`: [`TriggeredStep`](#interfacestriggeredstepmd)[] }
 
 Used for some more advanced callbacks
 
@@ -36,11 +35,11 @@ Used for some more advanced callbacks
 
 [voice-plus-web/src/configuration.ts:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L50)
 
-___
+---
 
 ### Method
 
-Ƭ **Method**: ``"AltText"`` \| ``"DisplayValue"`` \| ``"LabelText"`` \| ``"PlaceholderText"`` \| ``"Role"`` \| ``"TestId"`` \| ``"Text"`` \| ``"Title"`` \| ``"QuerySelector"``
+Ƭ **Method**: `"AltText"` \| `"DisplayValue"` \| `"LabelText"` \| `"PlaceholderText"` \| `"Role"` \| `"TestId"` \| `"Text"` \| `"Title"` \| `"QuerySelector"`
 
 Matching method
 
@@ -48,7 +47,7 @@ Matching method
 
 [voice-plus-web/src/queries.ts:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L10)
 
-___
+---
 
 ### Triggers
 
@@ -60,7 +59,7 @@ A record of triggers
 
 [voice-plus-web/src/trigger.ts:36](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L36)
 
-___
+---
 
 ### StepId
 
@@ -82,11 +81,11 @@ Icon URL's
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name           | Type     | Description        |
+| :------------- | :------- | :----------------- |
 | `supportAgent` | `string` | Support agent icon |
-| `callEnd` | `string` | Call end icon |
-| `multimodal` | `string` | Multimodal icon |
+| `callEnd`      | `string` | Call end icon      |
+| `multimodal`   | `string` | Multimodal icon    |
 
 #### Defined in
 
@@ -102,8 +101,8 @@ Run the Voice+ script
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                | Description                  |
+| :------ | :---------------------------------- | :--------------------------- |
 | `props` | [`RunProps`](#interfacesrunpropsmd) | The run configuration object |
 
 #### Returns
@@ -116,12 +115,9 @@ an promise of an object containing a teardown function and the Voice+ client.
 
 [voice-plus-web/src/index.ts:85](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L85)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfacesbuttonconfigmd"></a>
 
@@ -141,7 +137,7 @@ Button label
 
 [voice-plus-web/src/configuration.ts:62](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L62)
 
-___
+---
 
 #### confirmation
 
@@ -153,7 +149,7 @@ Button confirmation: if present, the button click handler only triggers after th
 
 [voice-plus-web/src/configuration.ts:66](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L66)
 
-___
+---
 
 #### iconUrl
 
@@ -165,7 +161,7 @@ Icon URL
 
 [voice-plus-web/src/configuration.ts:70](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L70)
 
-___
+---
 
 #### onClick
 
@@ -179,8 +175,8 @@ Click handler
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                        |
+| :------- | :-------------------------- |
 | `config` | [`HandlerArg`](#handlerarg) |
 
 ###### Returns
@@ -190,7 +186,6 @@ Click handler
 ##### Defined in
 
 [voice-plus-web/src/configuration.ts:74](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L74)
-
 
 <a name="interfacesencodedquerymd"></a>
 
@@ -210,7 +205,7 @@ Query name
 
 [voice-plus-web/src/queries.ts:60](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L60)
 
-___
+---
 
 #### target
 
@@ -222,11 +217,11 @@ Query target
 
 [voice-plus-web/src/queries.ts:64](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L64)
 
-___
+---
 
 #### options
 
-• **options**: ``null`` \| `Record`\<`string`, `boolean` \| [`SerializedRegex`](#interfacesserializedregexmd)\>
+• **options**: `null` \| `Record`\<`string`, `boolean` \| [`SerializedRegex`](#interfacesserializedregexmd)\>
 
 Query options
 
@@ -234,18 +229,17 @@ Query options
 
 [voice-plus-web/src/queries.ts:68](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L68)
 
-___
+---
 
 #### parent
 
-• **parent**: ``null`` \| [`EncodedQuery`](#interfacesencodedquerymd)
+• **parent**: `null` \| [`EncodedQuery`](#interfacesencodedquerymd)
 
 Query parent
 
 ##### Defined in
 
 [voice-plus-web/src/queries.ts:72](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L72)
-
 
 <a name="interfacesrunoutputmd"></a>
 
@@ -273,7 +267,7 @@ Stop running the journey, removing all event listeners
 
 [voice-plus-web/src/index.ts:73](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L73)
 
-___
+---
 
 #### client
 
@@ -284,7 +278,6 @@ The regular Voice+ SDK client
 ##### Defined in
 
 [voice-plus-web/src/index.ts:77](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L77)
-
 
 <a name="interfacesrunpropsmd"></a>
 
@@ -304,7 +297,7 @@ The regular Voice+ configuration
 
 [voice-plus-web/src/index.ts:46](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L46)
 
-___
+---
 
 #### ui
 
@@ -316,7 +309,7 @@ UI configuration
 
 [voice-plus-web/src/index.ts:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L50)
 
-___
+---
 
 #### triggers
 
@@ -329,7 +322,7 @@ If triggers are not provided, they will be fetched from the CDN.
 
 [voice-plus-web/src/index.ts:55](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L55)
 
-___
+---
 
 #### onDigression
 
@@ -343,8 +336,8 @@ Digression detection callback
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type     |
+| :------- | :------- |
 | `client` | `Client` |
 
 ###### Returns
@@ -355,7 +348,7 @@ Digression detection callback
 
 [voice-plus-web/src/index.ts:59](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L59)
 
-___
+---
 
 #### onStep
 
@@ -369,8 +362,8 @@ Runs when a step is triggered, used primarily for debugging
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type     |
+| :------- | :------- |
 | `stepId` | `string` |
 
 ###### Returns
@@ -380,7 +373,6 @@ Runs when a step is triggered, used primarily for debugging
 ##### Defined in
 
 [voice-plus-web/src/index.ts:63](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/index.ts#L63)
-
 
 <a name="interfacesserializedregexmd"></a>
 
@@ -400,7 +392,7 @@ Regex body
 
 [voice-plus-web/src/queries.ts:46](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L46)
 
-___
+---
 
 #### flags
 
@@ -411,7 +403,6 @@ Regex flags
 ##### Defined in
 
 [voice-plus-web/src/queries.ts:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/queries.ts#L50)
-
 
 <a name="interfacessimplehandlerargmd"></a>
 
@@ -433,10 +424,10 @@ A function to send steps to NLX.
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `step` | `StepInfo` |
-| `context?` | `Context` |
+| Name       | Type       |
+| :--------- | :--------- |
+| `step`     | `StepInfo` |
+| `context?` | `Context`  |
 
 ###### Returns
 
@@ -445,7 +436,6 @@ A function to send steps to NLX.
 ##### Defined in
 
 [voice-plus-web/src/configuration.ts:46](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L46)
-
 
 <a name="interfacesthememd"></a>
 
@@ -465,7 +455,7 @@ UI colors
 
 [voice-plus-web/src/configuration.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L28)
 
-___
+---
 
 #### fontFamily
 
@@ -476,7 +466,6 @@ Font family
 ##### Defined in
 
 [voice-plus-web/src/configuration.ts:32](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L32)
-
 
 <a name="interfacesthemecolorsmd"></a>
 
@@ -496,7 +485,7 @@ Primary color
 
 [voice-plus-web/src/configuration.ts:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L10)
 
-___
+---
 
 #### primaryHover
 
@@ -508,7 +497,7 @@ Primary color on hover
 
 [voice-plus-web/src/configuration.ts:14](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L14)
 
-___
+---
 
 #### highlight
 
@@ -520,7 +509,6 @@ Color for trigger highlights
 
 [voice-plus-web/src/configuration.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L18)
 
-
 <a name="interfacestriggermd"></a>
 
 ## Interface: Trigger
@@ -531,7 +519,7 @@ A single trigger
 
 #### event
 
-• **event**: ``"click"`` \| ``"pageLoad"`` \| ``"appear"`` \| ``"enterViewport"``
+• **event**: `"click"` \| `"pageLoad"` \| `"appear"` \| `"enterViewport"`
 
 Event
 
@@ -539,7 +527,7 @@ Event
 
 [voice-plus-web/src/trigger.ts:14](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L14)
 
-___
+---
 
 #### query
 
@@ -551,7 +539,7 @@ A query identifying the element
 
 [voice-plus-web/src/trigger.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L18)
 
-___
+---
 
 #### once
 
@@ -563,7 +551,7 @@ A flag specifying whether the trigger should only fire a single time
 
 [voice-plus-web/src/trigger.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L22)
 
-___
+---
 
 #### highlight
 
@@ -575,7 +563,7 @@ A flag specifying whether the trigger should highlight. Only applicable to click
 
 [voice-plus-web/src/trigger.ts:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L26)
 
-___
+---
 
 #### urlCondition
 
@@ -586,7 +574,6 @@ URL condition
 ##### Defined in
 
 [voice-plus-web/src/trigger.ts:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/trigger.ts#L30)
-
 
 <a name="interfacestriggeredstepmd"></a>
 
@@ -606,7 +593,7 @@ step id
 
 [voice-plus-web/src/configuration.ts:38](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L38)
 
-___
+---
 
 #### url
 
@@ -617,7 +604,6 @@ the URL of the page it triggered on
 ##### Defined in
 
 [voice-plus-web/src/configuration.ts:40](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L40)
-
 
 <a name="interfacesuiconfigmd"></a>
 
@@ -637,7 +623,7 @@ Drawer title
 
 [voice-plus-web/src/configuration.ts:84](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L84)
 
-___
+---
 
 #### subtitle
 
@@ -649,7 +635,7 @@ Drawer subtitle
 
 [voice-plus-web/src/configuration.ts:88](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L88)
 
-___
+---
 
 #### highlights
 
@@ -661,7 +647,7 @@ Render highlights
 
 [voice-plus-web/src/configuration.ts:92](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L92)
 
-___
+---
 
 #### iconUrl
 
@@ -673,7 +659,7 @@ URL for the button icon
 
 [voice-plus-web/src/configuration.ts:101](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L101)
 
-___
+---
 
 #### theme
 
@@ -685,7 +671,7 @@ UI theme
 
 [voice-plus-web/src/configuration.ts:105](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L105)
 
-___
+---
 
 #### onEscalation
 
@@ -699,8 +685,8 @@ Escalation handler
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                                                |
+| :------- | :-------------------------------------------------- |
 | `config` | [`SimpleHandlerArg`](#interfacessimplehandlerargmd) |
 
 ###### Returns
@@ -711,7 +697,7 @@ Escalation handler
 
 [voice-plus-web/src/configuration.ts:109](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L109)
 
-___
+---
 
 #### escalationButtonLabel
 
@@ -723,7 +709,7 @@ Escalation button label
 
 [voice-plus-web/src/configuration.ts:113](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L113)
 
-___
+---
 
 #### escalationConfirmation
 
@@ -735,7 +721,7 @@ Escalation confirmation
 
 [voice-plus-web/src/configuration.ts:117](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L117)
 
-___
+---
 
 #### onEnd
 
@@ -749,8 +735,8 @@ End handler
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                                                |
+| :------- | :-------------------------------------------------- |
 | `config` | [`SimpleHandlerArg`](#interfacessimplehandlerargmd) |
 
 ###### Returns
@@ -761,7 +747,7 @@ End handler
 
 [voice-plus-web/src/configuration.ts:121](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L121)
 
-___
+---
 
 #### endButtonLabel
 
@@ -773,7 +759,7 @@ End button label
 
 [voice-plus-web/src/configuration.ts:125](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L125)
 
-___
+---
 
 #### endConfirmation
 
@@ -785,7 +771,7 @@ End confirmation
 
 [voice-plus-web/src/configuration.ts:129](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L129)
 
-___
+---
 
 #### onPreviousStep
 
@@ -799,8 +785,8 @@ On previous step
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                        |
+| :------- | :-------------------------- |
 | `config` | [`HandlerArg`](#handlerarg) |
 
 ###### Returns
@@ -811,7 +797,7 @@ On previous step
 
 [voice-plus-web/src/configuration.ts:133](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L133)
 
-___
+---
 
 #### previousStepButtonLabel
 
@@ -823,7 +809,7 @@ Previous step button label
 
 [voice-plus-web/src/configuration.ts:137](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L137)
 
-___
+---
 
 #### buttons
 
@@ -835,7 +821,7 @@ Custom buttons
 
 [voice-plus-web/src/configuration.ts:141](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L141)
 
-___
+---
 
 #### nudgeContent
 
@@ -848,7 +834,7 @@ it will be shown only if the user never interacts with the overlay pin, after `t
 
 [voice-plus-web/src/configuration.ts:146](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L146)
 
-___
+---
 
 #### nudgeShowAfterMs
 
@@ -860,7 +846,7 @@ Show nudge tooltip after this many milliseconds
 
 [voice-plus-web/src/configuration.ts:150](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L150)
 
-___
+---
 
 #### nudgeHideAfterMs
 
@@ -872,7 +858,6 @@ Hide nudge tooltip after it's been shown for this many milliseconds
 
 [voice-plus-web/src/configuration.ts:154](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/configuration.ts#L154)
 
-
 <a name="interfacesurlconditionmd"></a>
 
 ## Interface: UrlCondition
@@ -883,7 +868,7 @@ URL match condition
 
 #### operator
 
-• **operator**: ``"contains"`` \| ``"matches_regex"`` \| ``"smart_match"``
+• **operator**: `"contains"` \| `"matches_regex"` \| `"smart_match"`
 
 Condition operator
 
@@ -891,7 +876,7 @@ Condition operator
 
 [voice-plus-web/src/UrlCondition.ts:8](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-web/src/UrlCondition.ts#L8)
 
-___
+---
 
 #### value
 

--- a/packages/website/src/content/touchpoint-ui-api-reference.md
+++ b/packages/website/src/content/touchpoint-ui-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/touchpoint-ui
@@ -32,11 +31,11 @@ Accessibility information
 
 [packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:9](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L9)
 
-___
+---
 
 ### IconButtonType
 
-Ƭ **IconButtonType**: ``"main"`` \| ``"ghost"`` \| ``"activated"`` \| ``"coverup"`` \| ``"error"`` \| ``"overlay"``
+Ƭ **IconButtonType**: `"main"` \| `"ghost"` \| `"activated"` \| `"coverup"` \| `"error"` \| `"overlay"`
 
 Represents the different types of icon buttons available in the application.
 
@@ -50,11 +49,11 @@ Represents the different types of icon buttons available in the application.
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L16)
 
-___
+---
 
 ### WindowSize
 
-Ƭ **WindowSize**: ``"half"`` \| ``"full"``
+Ƭ **WindowSize**: `"half"` \| `"full"`
 
 Window size configuration
 
@@ -62,11 +61,11 @@ Window size configuration
 
 [packages/touchpoint-ui/src/types.ts:12](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L12)
 
-___
+---
 
 ### ColorMode
 
-Ƭ **ColorMode**: ``"light"`` \| ``"dark"``
+Ƭ **ColorMode**: `"light"` \| `"dark"`
 
 Color mode configuration (light/dark modes)
 
@@ -74,26 +73,26 @@ Color mode configuration (light/dark modes)
 
 [packages/touchpoint-ui/src/types.ts:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L17)
 
-___
+---
 
 ### CustomModalityComponent
 
-Ƭ **CustomModalityComponent**\<`Data`\>: `ComponentType`\<\{ `data`: `Data` ; `conversationHandler`: `ConversationHandler` ; `enabled`: `boolean`  }\>
+Ƭ **CustomModalityComponent**\<`Data`\>: `ComponentType`\<\{ `data`: `Data` ; `conversationHandler`: `ConversationHandler` ; `enabled`: `boolean` }\>
 
 Custom Modalities allow rendering of rich components from nodes.
 See: https://docs.studio.nlx.ai/build/resources/modalities
 
 #### Type parameters
 
-| Name |
-| :------ |
+| Name   |
+| :----- |
 | `Data` |
 
 #### Defined in
 
 [packages/touchpoint-ui/src/types.ts:41](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L41)
 
-___
+---
 
 ### InitializeConversation
 
@@ -107,10 +106,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `handler` | `ConversationHandler` | the conversation handler. |
-| `context?` | `Context` | context set via TouchpointConfiguration.initialContext |
+| Name       | Type                  | Description                                            |
+| :--------- | :-------------------- | :----------------------------------------------------- |
+| `handler`  | `ConversationHandler` | the conversation handler.                              |
+| `context?` | `Context`             | context set via TouchpointConfiguration.initialContext |
 
 ##### Returns
 
@@ -120,11 +119,11 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 [packages/touchpoint-ui/src/types.ts:175](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L175)
 
-___
+---
 
 ### CustomLaunchButton
 
-Ƭ **CustomLaunchButton**: `ComponentType`\<\{ `className?`: `string` ; `onClick?`: () => `void`  }\>
+Ƭ **CustomLaunchButton**: `ComponentType`\<\{ `className?`: `string` ; `onClick?`: () => `void` }\>
 
 Fully custom launch icon
 
@@ -132,11 +131,11 @@ Fully custom launch icon
 
 [packages/touchpoint-ui/src/types.ts:183](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L183)
 
-___
+---
 
 ### Input
 
-Ƭ **Input**: ``"text"`` \| ``"voice"`` \| ``"voiceMini"``
+Ƭ **Input**: `"text"` \| `"voice"` \| `"voiceMini"`
 
 Input type for the experience
 
@@ -144,11 +143,11 @@ Input type for the experience
 
 [packages/touchpoint-ui/src/types.ts:197](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L197)
 
-___
+---
 
 ### BidirectionalConfig
 
-Ƭ **BidirectionalConfig**: \{ `automaticContext?`: ``true`` ; `navigation?`: (`action`: ``"page_next"`` \| ``"page_previous"`` \| ``"page_custom"``, `destination`: `string` \| `undefined`, `destinations`: `Record`\<`string`, `string`\>) => `void` ; `input?`: (`fields`: \{ `id`: `string` ; `value`: `string`  }[], `pageFields`: `Record`\<`string`, `Element`\>) => `void` ; `custom?`: (`action`: `string`, `payload`: `unknown`) => `void`  } \| \{ `automaticContext`: ``false`` ; `navigation?`: (`action`: ``"page_next"`` \| ``"page_previous"`` \| ``"page_custom"``, `destination?`: `string`) => `void` ; `input?`: (`fields`: \{ `id`: `string` ; `value`: `string`  }[]) => `void` ; `custom?`: (`action`: `string`, `payload`: `unknown`) => `void`  }
+Ƭ **BidirectionalConfig**: \{ `automaticContext?`: `true` ; `navigation?`: (`action`: `"page_next"` \| `"page_previous"` \| `"page_custom"`, `destination`: `string` \| `undefined`, `destinations`: `Record`\<`string`, `string`\>) => `void` ; `input?`: (`fields`: \{ `id`: `string` ; `value`: `string` }[], `pageFields`: `Record`\<`string`, `Element`\>) => `void` ; `custom?`: (`action`: `string`, `payload`: `unknown`) => `void` } \| \{ `automaticContext`: `false` ; `navigation?`: (`action`: `"page_next"` \| `"page_previous"` \| `"page_custom"`, `destination?`: `string`) => `void` ; `input?`: (`fields`: \{ `id`: `string` ; `value`: `string` }[]) => `void` ; `custom?`: (`action`: `string`, `payload`: `unknown`) => `void` }
 
 Configuration for bidirectional mode of voice+.
 
@@ -186,7 +185,7 @@ pageForms
 
 [packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:71](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L71)
 
-___
+---
 
 ### Ripple
 
@@ -194,12 +193,12 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | - |
-| `props.className?` | `string` | - |
-| `props.style?` | `CSSProperties` | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type            | Description                                                                                                                           |
+| :------------------------- | :-------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | `Object`        | -                                                                                                                                     |
+| `props.className?`         | `string`        | -                                                                                                                                     |
+| `props.style?`             | `CSSProperties` | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`           | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -209,7 +208,7 @@ ___
 
 [packages/touchpoint-ui/src/components/Ripple.tsx:24](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/Ripple.tsx#L24)
 
-___
+---
 
 ### Carousel
 
@@ -217,11 +216,11 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | - |
-| `props.children` | `ReactNode` | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type        | Description                                                                                                                           |
+| :------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | `Object`    | -                                                                                                                                     |
+| `props.children`           | `ReactNode` | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`       | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -231,7 +230,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Carousel.tsx:5](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Carousel.tsx#L5)
 
-___
+---
 
 ### CustomCard
 
@@ -239,10 +238,10 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`CustomCardProps`](#interfacescustomcardpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                              | Description                                                                                                                           |
+| :------------------------- | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`CustomCardProps`](#interfacescustomcardpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                             | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -252,7 +251,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L33)
 
-___
+---
 
 ### CustomCardImageRow
 
@@ -260,12 +259,12 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | - |
-| `props.src` | `string` | - |
-| `props.alt?` | `string` | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type     | Description                                                                                                                           |
+| :------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | `Object` | -                                                                                                                                     |
+| `props.src`                | `string` | -                                                                                                                                     |
+| `props.alt?`               | `string` | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`    | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -275,7 +274,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:76](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L76)
 
-___
+---
 
 ### CustomCardRow
 
@@ -283,10 +282,10 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`CustomCardRowProps`](#interfacescustomcardrowpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                                    | Description                                                                                                                           |
+| :------------------------- | :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`CustomCardRowProps`](#interfacescustomcardrowpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                                   | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -296,7 +295,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:101](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L101)
 
-___
+---
 
 ### DateInput
 
@@ -304,10 +303,10 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`DateInputProps`](#interfacesdateinputpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                            | Description                                                                                                                           |
+| :------------------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`DateInputProps`](#interfacesdateinputpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                           | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -317,7 +316,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/DateInput.tsx:25](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L25)
 
-___
+---
 
 ### IconButton
 
@@ -325,10 +324,10 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconButtonProps`](#interfacesiconbuttonpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                              | Description                                                                                                                           |
+| :------------------------- | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconButtonProps`](#interfacesiconbuttonpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                             | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -338,7 +337,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:94](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L94)
 
-___
+---
 
 ### TextButton
 
@@ -346,10 +345,10 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`TextButtonProps`](#interfacestextbuttonpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                              | Description                                                                                                                           |
+| :------------------------- | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`TextButtonProps`](#interfacestextbuttonpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                             | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -359,7 +358,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/TextButton.tsx:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L33)
 
-___
+---
 
 ### BaseText
 
@@ -367,12 +366,12 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | - |
-| `props.children` | `ReactNode` | - |
-| `props.faded?` | `boolean` | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type        | Description                                                                                                                           |
+| :------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | `Object`    | -                                                                                                                                     |
+| `props.children`           | `ReactNode` | -                                                                                                                                     |
+| `props.faded?`             | `boolean`   | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`       | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -382,7 +381,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Typography.tsx:5](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Typography.tsx#L5)
 
-___
+---
 
 ### SmallText
 
@@ -390,11 +389,11 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | - |
-| `props.children` | `ReactNode` | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type        | Description                                                                                                                           |
+| :------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | `Object`    | -                                                                                                                                     |
+| `props.children`           | `ReactNode` | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`       | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -404,7 +403,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Typography.tsx:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Typography.tsx#L16)
 
-___
+---
 
 ### html
 
@@ -412,10 +411,10 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `strings` | `TemplateStringsArray` |
-| `...values` | `any`[] |
+| Name        | Type                   |
+| :---------- | :--------------------- |
+| `strings`   | `TemplateStringsArray` |
+| `...values` | `any`[]                |
 
 #### Returns
 
@@ -425,7 +424,7 @@ ___
 
 [packages/touchpoint-ui/src/index.tsx:59](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L59)
 
-___
+---
 
 ### create
 
@@ -435,8 +434,8 @@ Creates a new Touchpoint UI instance and appends it to the document body
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                                              | Description                        |
+| :------ | :---------------------------------------------------------------- | :--------------------------------- |
 | `props` | [`TouchpointConfiguration`](#interfacestouchpointconfigurationmd) | Configuration props for Touchpoint |
 
 #### Returns
@@ -449,7 +448,7 @@ A promise that resolves to a TouchpointInstance
 
 [packages/touchpoint-ui/src/index.tsx:320](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L320)
 
-___
+---
 
 ### PreviewContainer
 
@@ -457,13 +456,13 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `Object` | - |
-| `props.children` | `ReactNode` | - |
-| `props.mode` | [`ColorMode`](#colormode) | - |
-| `props.theme` | `Partial`\<[`Theme`](#interfacesthememd)\> | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | `Object`                                   | -                                                                                                                                     |
+| `props.children`           | `ReactNode`                                | -                                                                                                                                     |
+| `props.mode`               | [`ColorMode`](#colormode)                  | -                                                                                                                                     |
+| `props.theme`              | `Partial`\<[`Theme`](#interfacesthememd)\> | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -473,12 +472,9 @@ ___
 
 [packages/touchpoint-ui/src/preview.tsx:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/preview.tsx#L10)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfacescustomcardpropsmd"></a>
 
@@ -498,7 +494,7 @@ Content to be rendered inside the card.
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:14](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L14)
 
-___
+---
 
 #### selected
 
@@ -510,7 +506,7 @@ Whether the card is in a selected state. Used to highlight the card.
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L18)
 
-___
+---
 
 #### onClick
 
@@ -530,7 +526,7 @@ Handler function for when the card is clicked
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L22)
 
-___
+---
 
 #### href
 
@@ -542,7 +538,7 @@ Transform the card into an anchor tag with the href specified
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L26)
 
-___
+---
 
 #### newTab
 
@@ -553,7 +549,6 @@ Specify whether the URL should take the user to a new tab
 ##### Defined in
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L30)
-
 
 <a name="interfacescustomcardrowpropsmd"></a>
 
@@ -573,7 +568,7 @@ Content to be displayed on the left side of the row
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:90](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L90)
 
-___
+---
 
 #### right
 
@@ -585,7 +580,7 @@ Content to be displayed on the right side of the row
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:94](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L94)
 
-___
+---
 
 #### icon
 
@@ -596,7 +591,6 @@ Optional icon to be displayed in the center of the row
 ##### Defined in
 
 [packages/touchpoint-ui/src/components/ui/CustomCard.tsx:98](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L98)
-
 
 <a name="interfacesdateinputpropsmd"></a>
 
@@ -618,8 +612,8 @@ Handler function called when the date is submitted
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name   | Type     | Description                             |
+| :----- | :------- | :-------------------------------------- |
 | `date` | `string` | The submitted date in YYYY-MM-DD format |
 
 ###### Returns
@@ -629,7 +623,6 @@ Handler function called when the date is submitted
 ##### Defined in
 
 [packages/touchpoint-ui/src/components/ui/DateInput.tsx:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L16)
-
 
 <a name="interfacesiconbuttonpropsmd"></a>
 
@@ -657,7 +650,7 @@ Handler function called when the button is clicked
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:31](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L31)
 
-___
+---
 
 #### label
 
@@ -669,7 +662,7 @@ Accessible label for the button
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:35](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L35)
 
-___
+---
 
 #### className
 
@@ -681,7 +674,7 @@ Additional CSS classes to apply to the button
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:39](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L39)
 
-___
+---
 
 #### type
 
@@ -693,7 +686,7 @@ Visual style variant of the button. One of IconButtonType.
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:43](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L43)
 
-___
+---
 
 #### Icon
 
@@ -704,7 +697,6 @@ Icon component to display inside the button
 ##### Defined in
 
 [packages/touchpoint-ui/src/components/ui/IconButton.tsx:47](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L47)
-
 
 <a name="interfacesiconsiconpropsmd"></a>
 
@@ -726,7 +718,7 @@ Additional CSS classes to apply to the icon
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:11](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L11)
 
-___
+---
 
 #### size
 
@@ -737,7 +729,6 @@ Custom size in pixels for the icon
 ##### Defined in
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:15](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L15)
-
 
 <a name="interfacesinteractiveelementinfomd"></a>
 
@@ -763,7 +754,6 @@ Form element ID (assigned by the analysis logic, not necessarily equal to the DO
 
 [packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L18)
 
-
 <a name="interfacespageformsmd"></a>
 
 ## Interface: PageForms
@@ -782,7 +772,7 @@ Page context
 
 [packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L28)
 
-___
+---
 
 #### formElements
 
@@ -793,7 +783,6 @@ Form element references
 ##### Defined in
 
 [packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:32](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L32)
-
 
 <a name="interfacestextbuttonpropsmd"></a>
 
@@ -821,7 +810,7 @@ Handler function called when the button is clicked
 
 [packages/touchpoint-ui/src/components/ui/TextButton.tsx:13](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L13)
 
-___
+---
 
 #### label
 
@@ -833,7 +822,7 @@ Text to display on the button
 
 [packages/touchpoint-ui/src/components/ui/TextButton.tsx:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L17)
 
-___
+---
 
 #### className
 
@@ -845,11 +834,11 @@ Additional CSS classes to apply to the button
 
 [packages/touchpoint-ui/src/components/ui/TextButton.tsx:21](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L21)
 
-___
+---
 
 #### type
 
-• `Optional` **type**: ``"main"`` \| ``"ghost"``
+• `Optional` **type**: `"main"` \| `"ghost"`
 
 Visual style variant of the button
 Default value is "ghost"
@@ -858,7 +847,7 @@ Default value is "ghost"
 
 [packages/touchpoint-ui/src/components/ui/TextButton.tsx:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L26)
 
-___
+---
 
 #### Icon
 
@@ -869,7 +858,6 @@ Icon component to display inside the button.
 ##### Defined in
 
 [packages/touchpoint-ui/src/components/ui/TextButton.tsx:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L30)
-
 
 <a name="interfacesthememd"></a>
 
@@ -889,7 +877,7 @@ Font family
 
 [packages/touchpoint-ui/src/types.ts:66](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L66)
 
-___
+---
 
 #### primary80
 
@@ -901,7 +889,7 @@ Primary color with 80% opacity
 
 [packages/touchpoint-ui/src/types.ts:71](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L71)
 
-___
+---
 
 #### primary60
 
@@ -913,7 +901,7 @@ Primary color with 60% opacity
 
 [packages/touchpoint-ui/src/types.ts:75](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L75)
 
-___
+---
 
 #### primary40
 
@@ -925,7 +913,7 @@ Primary color with 40% opacity
 
 [packages/touchpoint-ui/src/types.ts:79](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L79)
 
-___
+---
 
 #### primary20
 
@@ -937,7 +925,7 @@ Primary color with 20% opacity
 
 [packages/touchpoint-ui/src/types.ts:83](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L83)
 
-___
+---
 
 #### primary10
 
@@ -949,7 +937,7 @@ Primary color with 10% opacity
 
 [packages/touchpoint-ui/src/types.ts:87](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L87)
 
-___
+---
 
 #### primary5
 
@@ -961,7 +949,7 @@ Primary color with 5% opacity
 
 [packages/touchpoint-ui/src/types.ts:91](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L91)
 
-___
+---
 
 #### primary1
 
@@ -973,7 +961,7 @@ Primary color with 1% opacity
 
 [packages/touchpoint-ui/src/types.ts:95](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L95)
 
-___
+---
 
 #### secondary80
 
@@ -985,7 +973,7 @@ Secondary color with 80% opacity
 
 [packages/touchpoint-ui/src/types.ts:100](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L100)
 
-___
+---
 
 #### secondary60
 
@@ -997,7 +985,7 @@ Secondary color with 60% opacity
 
 [packages/touchpoint-ui/src/types.ts:104](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L104)
 
-___
+---
 
 #### secondary40
 
@@ -1009,7 +997,7 @@ Secondary color with 40% opacity
 
 [packages/touchpoint-ui/src/types.ts:108](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L108)
 
-___
+---
 
 #### secondary20
 
@@ -1021,7 +1009,7 @@ Secondary color with 20% opacity
 
 [packages/touchpoint-ui/src/types.ts:112](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L112)
 
-___
+---
 
 #### secondary10
 
@@ -1033,7 +1021,7 @@ Secondary color with 10% opacity
 
 [packages/touchpoint-ui/src/types.ts:116](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L116)
 
-___
+---
 
 #### secondary5
 
@@ -1045,7 +1033,7 @@ Secondary color with 5% opacity
 
 [packages/touchpoint-ui/src/types.ts:120](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L120)
 
-___
+---
 
 #### secondary1
 
@@ -1057,7 +1045,7 @@ Secondary color with 1% opacity
 
 [packages/touchpoint-ui/src/types.ts:124](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L124)
 
-___
+---
 
 #### accent
 
@@ -1069,7 +1057,7 @@ Accent color used e.g. for prominent buttons, the loader animation as well as se
 
 [packages/touchpoint-ui/src/types.ts:129](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L129)
 
-___
+---
 
 #### accent20
 
@@ -1081,7 +1069,7 @@ Accent color with 20% opacity
 
 [packages/touchpoint-ui/src/types.ts:133](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L133)
 
-___
+---
 
 #### background
 
@@ -1093,7 +1081,7 @@ The background color of the main Touchpoint interface
 
 [packages/touchpoint-ui/src/types.ts:137](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L137)
 
-___
+---
 
 #### overlay
 
@@ -1105,7 +1093,7 @@ The color of the overlay covering the visible portion of the website when the To
 
 [packages/touchpoint-ui/src/types.ts:141](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L141)
 
-___
+---
 
 #### warningPrimary
 
@@ -1117,7 +1105,7 @@ Primary warning color
 
 [packages/touchpoint-ui/src/types.ts:146](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L146)
 
-___
+---
 
 #### warningSecondary
 
@@ -1129,7 +1117,7 @@ Secondary warning color
 
 [packages/touchpoint-ui/src/types.ts:150](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L150)
 
-___
+---
 
 #### errorPrimary
 
@@ -1141,7 +1129,7 @@ Primary error color
 
 [packages/touchpoint-ui/src/types.ts:154](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L154)
 
-___
+---
 
 #### errorSecondary
 
@@ -1153,7 +1141,7 @@ Secondary error color
 
 [packages/touchpoint-ui/src/types.ts:158](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L158)
 
-___
+---
 
 #### innerBorderRadius
 
@@ -1165,7 +1153,7 @@ Inner border radius: used for most buttons
 
 [packages/touchpoint-ui/src/types.ts:163](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L163)
 
-___
+---
 
 #### outerBorderRadius
 
@@ -1176,7 +1164,6 @@ Outer border radius: generally used for elements that contain buttons that have 
 ##### Defined in
 
 [packages/touchpoint-ui/src/types.ts:167](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L167)
-
 
 <a name="interfacestouchpointconfigurationmd"></a>
 
@@ -1196,7 +1183,7 @@ Connection information for the @nlxai/chat-core conversation handler
 
 [packages/touchpoint-ui/src/types.ts:289](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L289)
 
-___
+---
 
 #### windowSize
 
@@ -1208,7 +1195,7 @@ Optional window size for the chat window, defaults to `half`
 
 [packages/touchpoint-ui/src/types.ts:293](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L293)
 
-___
+---
 
 #### colorMode
 
@@ -1220,7 +1207,7 @@ Optional color mode for the chat window, defaults to `dark`
 
 [packages/touchpoint-ui/src/types.ts:297](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L297)
 
-___
+---
 
 #### brandIcon
 
@@ -1232,7 +1219,7 @@ URL of icon used to display the brand in the chat header
 
 [packages/touchpoint-ui/src/types.ts:301](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L301)
 
-___
+---
 
 #### launchIcon
 
@@ -1246,7 +1233,7 @@ When set to `false`, no launch button is shown at all. When not set or set to `t
 
 [packages/touchpoint-ui/src/types.ts:307](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L307)
 
-___
+---
 
 #### userMessageBubble
 
@@ -1258,7 +1245,7 @@ Specifies whether the user message has bubbles or not
 
 [packages/touchpoint-ui/src/types.ts:311](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L311)
 
-___
+---
 
 #### agentMessageBubble
 
@@ -1270,7 +1257,7 @@ Specifies whether the agent message has bubbles or not
 
 [packages/touchpoint-ui/src/types.ts:315](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L315)
 
-___
+---
 
 #### chatMode
 
@@ -1282,7 +1269,7 @@ Enables chat mode, a classic chat experience with inline loaders and the chat hi
 
 [packages/touchpoint-ui/src/types.ts:319](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L319)
 
-___
+---
 
 #### theme
 
@@ -1294,7 +1281,7 @@ Optional theme object to override default theme values
 
 [packages/touchpoint-ui/src/types.ts:323](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L323)
 
-___
+---
 
 #### customModalities
 
@@ -1306,7 +1293,7 @@ Optional custom modality components to render in Touchpoint
 
 [packages/touchpoint-ui/src/types.ts:327](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L327)
 
-___
+---
 
 #### initializeConversation
 
@@ -1326,19 +1313,19 @@ the context object
 
 [packages/touchpoint-ui/src/types.ts:333](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L333)
 
-___
+---
 
 #### input
 
 • `Optional` **input**: [`Input`](#input)
 
-Controls the ways in which  the user can communicate with the application. Defaults to `"text"`
+Controls the ways in which the user can communicate with the application. Defaults to `"text"`
 
 ##### Defined in
 
 [packages/touchpoint-ui/src/types.ts:337](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L337)
 
-___
+---
 
 #### initialContext
 
@@ -1350,7 +1337,7 @@ Context sent with the initial request.
 
 [packages/touchpoint-ui/src/types.ts:341](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L341)
 
-___
+---
 
 #### bidirectional
 
@@ -1361,7 +1348,6 @@ Enables bidirectional mode of voice+. Will automatically set the bidirectional f
 ##### Defined in
 
 [packages/touchpoint-ui/src/types.ts:347](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L347)
-
 
 <a name="interfacestouchpointinstancemd"></a>
 
@@ -1381,7 +1367,7 @@ Controls whether the Touchpoint UI is expanded or collapsed
 
 [packages/touchpoint-ui/src/index.tsx:304](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L304)
 
-___
+---
 
 #### conversationHandler
 
@@ -1393,7 +1379,7 @@ The conversation handler instance for interacting with the application
 
 [packages/touchpoint-ui/src/index.tsx:308](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L308)
 
-___
+---
 
 #### teardown
 
@@ -1414,7 +1400,6 @@ Method to remove the Touchpoint UI from the DOM
 [packages/touchpoint-ui/src/index.tsx:312](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L312)
 
 # Modules
-
 
 <a name="modulesiconsmd"></a>
 
@@ -1444,10 +1429,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1457,7 +1442,7 @@ Type definition for an icon component
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:29](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L29)
 
-___
+---
 
 #### Touchpoint
 
@@ -1465,10 +1450,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1478,7 +1463,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:40](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L40)
 
-___
+---
 
 #### AssistantOld
 
@@ -1486,10 +1471,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1499,7 +1484,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:67](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L67)
 
-___
+---
 
 #### Add
 
@@ -1507,10 +1492,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1520,7 +1505,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:78](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L78)
 
-___
+---
 
 #### ArrowDown
 
@@ -1528,10 +1513,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1541,7 +1526,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:86](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L86)
 
-___
+---
 
 #### ArrowLeft
 
@@ -1549,10 +1534,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1562,7 +1547,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:97](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L97)
 
-___
+---
 
 #### ArrowRight
 
@@ -1570,10 +1555,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1583,7 +1568,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:108](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L108)
 
-___
+---
 
 #### ArrowUp
 
@@ -1591,10 +1576,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1604,7 +1589,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:119](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L119)
 
-___
+---
 
 #### ArrowForward
 
@@ -1612,10 +1597,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1625,7 +1610,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:130](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L130)
 
-___
+---
 
 #### Attachment
 
@@ -1633,10 +1618,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1646,7 +1631,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:141](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L141)
 
-___
+---
 
 #### Camera
 
@@ -1654,10 +1639,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1667,7 +1652,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:152](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L152)
 
-___
+---
 
 #### Check
 
@@ -1675,10 +1660,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1688,7 +1673,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:167](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L167)
 
-___
+---
 
 #### Close
 
@@ -1696,10 +1681,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1709,7 +1694,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:178](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L178)
 
-___
+---
 
 #### Copy
 
@@ -1717,10 +1702,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1730,7 +1715,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:189](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L189)
 
-___
+---
 
 #### Date
 
@@ -1738,10 +1723,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1751,7 +1736,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:200](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L200)
 
-___
+---
 
 #### Delete
 
@@ -1759,10 +1744,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1772,7 +1757,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:211](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L211)
 
-___
+---
 
 #### Escalate
 
@@ -1780,10 +1765,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1793,7 +1778,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:225](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L225)
 
-___
+---
 
 #### Error
 
@@ -1801,10 +1786,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1814,7 +1799,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:248](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L248)
 
-___
+---
 
 #### FullScreen
 
@@ -1822,10 +1807,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1835,7 +1820,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:259](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L259)
 
-___
+---
 
 #### Mic
 
@@ -1843,10 +1828,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1856,7 +1841,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:270](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L270)
 
-___
+---
 
 #### MicOff
 
@@ -1864,10 +1849,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1877,7 +1862,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:281](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L281)
 
-___
+---
 
 #### Location
 
@@ -1885,10 +1870,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1898,7 +1883,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:292](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L292)
 
-___
+---
 
 #### Volume
 
@@ -1906,10 +1891,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1919,7 +1904,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:303](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L303)
 
-___
+---
 
 #### VolumeOff
 
@@ -1927,10 +1912,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1940,7 +1925,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:314](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L314)
 
-___
+---
 
 #### Translate
 
@@ -1948,10 +1933,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1961,7 +1946,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:325](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L325)
 
-___
+---
 
 #### OpenInNew
 
@@ -1969,10 +1954,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1982,7 +1967,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:336](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L336)
 
-___
+---
 
 #### Play
 
@@ -1990,10 +1975,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2003,7 +1988,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:347](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L347)
 
-___
+---
 
 #### Preview
 
@@ -2011,10 +1996,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2024,7 +2009,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:355](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L355)
 
-___
+---
 
 #### Reorder
 
@@ -2032,10 +2017,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2045,7 +2030,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:372](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L372)
 
-___
+---
 
 #### Restart
 
@@ -2053,10 +2038,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2066,7 +2051,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:383](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L383)
 
-___
+---
 
 #### Settings
 
@@ -2074,10 +2059,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2087,7 +2072,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:394](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L394)
 
-___
+---
 
 #### Search
 
@@ -2095,10 +2080,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2108,7 +2093,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:405](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L405)
 
-___
+---
 
 #### Share
 
@@ -2116,10 +2101,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2129,7 +2114,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:416](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L416)
 
-___
+---
 
 #### Warning
 
@@ -2137,10 +2122,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2150,7 +2135,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:427](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L427)
 
-___
+---
 
 #### ThumbDown
 
@@ -2158,10 +2143,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2171,7 +2156,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:438](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L438)
 
-___
+---
 
 #### ThumbUp
 
@@ -2179,10 +2164,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2192,7 +2177,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:449](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L449)
 
-___
+---
 
 #### Time
 
@@ -2200,10 +2185,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2213,7 +2198,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:460](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L460)
 
-___
+---
 
 #### Undo
 
@@ -2221,10 +2206,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2234,7 +2219,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:477](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L477)
 
-___
+---
 
 #### Refresh
 
@@ -2242,10 +2227,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2255,7 +2240,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:488](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L488)
 
-___
+---
 
 #### Help
 
@@ -2263,10 +2248,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2276,7 +2261,7 @@ ___
 
 [packages/touchpoint-ui/src/components/ui/Icons.tsx:499](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L499)
 
-___
+---
 
 #### OpenLink
 
@@ -2284,10 +2269,10 @@ ___
 
 ##### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
-| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name                       | Type                                       | Description                                                                                                                           |
+| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
+| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 

--- a/packages/website/src/content/touchpoint-ui-api-reference.md
+++ b/packages/website/src/content/touchpoint-ui-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/touchpoint-ui
@@ -8,6 +9,8 @@
 
 ## Interfaces
 
+- [InteractiveElementInfo](#interfacesinteractiveelementinfomd)
+- [PageForms](#interfacespageformsmd)
 - [CustomCardProps](#interfacescustomcardpropsmd)
 - [CustomCardRowProps](#interfacescustomcardrowpropsmd)
 - [DateInputProps](#interfacesdateinputpropsmd)
@@ -19,9 +22,21 @@
 
 ## Type Aliases
 
+### AccessibilityInformation
+
+Ƭ **AccessibilityInformation**: `Record`\<`string`, `any`\>
+
+Accessibility information
+
+#### Defined in
+
+[packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:9](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L9)
+
+___
+
 ### IconButtonType
 
-Ƭ **IconButtonType**: `"main"` \| `"ghost"` \| `"activated"` \| `"coverup"` \| `"error"` \| `"overlay"`
+Ƭ **IconButtonType**: ``"main"`` \| ``"ghost"`` \| ``"activated"`` \| ``"coverup"`` \| ``"error"`` \| ``"overlay"``
 
 Represents the different types of icon buttons available in the application.
 
@@ -33,68 +48,69 @@ Represents the different types of icon buttons available in the application.
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:16](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L16)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L16)
 
----
+___
 
 ### WindowSize
 
-Ƭ **WindowSize**: `"half"` \| `"full"`
+Ƭ **WindowSize**: ``"half"`` \| ``"full"``
 
 Window size configuration
 
 #### Defined in
 
-[packages/touchpoint-ui/src/types.ts:7](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L7)
+[packages/touchpoint-ui/src/types.ts:12](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L12)
 
----
+___
 
 ### ColorMode
 
-Ƭ **ColorMode**: `"light"` \| `"dark"`
+Ƭ **ColorMode**: ``"light"`` \| ``"dark"``
 
 Color mode configuration (light/dark modes)
 
 #### Defined in
 
-[packages/touchpoint-ui/src/types.ts:12](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L12)
+[packages/touchpoint-ui/src/types.ts:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L17)
 
----
+___
 
 ### CustomModalityComponent
 
-Ƭ **CustomModalityComponent**\<`Data`\>: `FC`\<\{ `data`: `Data` ; `conversationHandler`: `ConversationHandler` ; `enabled`: `boolean` }\>
+Ƭ **CustomModalityComponent**\<`Data`\>: `ComponentType`\<\{ `data`: `Data` ; `conversationHandler`: `ConversationHandler` ; `enabled`: `boolean`  }\>
 
 Custom Modalities allow rendering of rich components from nodes.
 See: https://docs.studio.nlx.ai/build/resources/modalities
 
 #### Type parameters
 
-| Name   |
-| :----- |
+| Name |
+| :------ |
 | `Data` |
 
 #### Defined in
 
-[packages/touchpoint-ui/src/types.ts:36](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L36)
+[packages/touchpoint-ui/src/types.ts:41](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L41)
 
----
+___
 
 ### InitializeConversation
 
-Ƭ **InitializeConversation**: (`handler`: `ConversationHandler`) => `void`
+Ƭ **InitializeConversation**: (`handler`: `ConversationHandler`, `context?`: `Context`) => `void`
 
 Custom conversation init method. Defaults to sending the welcome intent
 
 #### Type declaration
 
-▸ (`handler`): `void`
+▸ (`handler`, `context?`): `void`
 
 ##### Parameters
 
-| Name      | Type                  | Description               |
-| :-------- | :-------------------- | :------------------------ |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `handler` | `ConversationHandler` | the conversation handler. |
+| `context?` | `Context` | context set via TouchpointConfiguration.initialContext |
 
 ##### Returns
 
@@ -102,9 +118,98 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/types.ts:169](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L169)
+[packages/touchpoint-ui/src/types.ts:175](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L175)
+
+___
+
+### CustomLaunchButton
+
+Ƭ **CustomLaunchButton**: `ComponentType`\<\{ `className?`: `string` ; `onClick?`: () => `void`  }\>
+
+Fully custom launch icon
+
+#### Defined in
+
+[packages/touchpoint-ui/src/types.ts:183](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L183)
+
+___
+
+### Input
+
+Ƭ **Input**: ``"text"`` \| ``"voice"`` \| ``"voiceMini"``
+
+Input type for the experience
+
+#### Defined in
+
+[packages/touchpoint-ui/src/types.ts:197](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L197)
+
+___
+
+### BidirectionalConfig
+
+Ƭ **BidirectionalConfig**: \{ `automaticContext?`: ``true`` ; `navigation?`: (`action`: ``"page_next"`` \| ``"page_previous"`` \| ``"page_custom"``, `destination`: `string` \| `undefined`, `destinations`: `Record`\<`string`, `string`\>) => `void` ; `input?`: (`fields`: \{ `id`: `string` ; `value`: `string`  }[], `pageFields`: `Record`\<`string`, `Element`\>) => `void` ; `custom?`: (`action`: `string`, `payload`: `unknown`) => `void`  } \| \{ `automaticContext`: ``false`` ; `navigation?`: (`action`: ``"page_next"`` \| ``"page_previous"`` \| ``"page_custom"``, `destination?`: `string`) => `void` ; `input?`: (`fields`: \{ `id`: `string` ; `value`: `string`  }[]) => `void` ; `custom?`: (`action`: `string`, `payload`: `unknown`) => `void`  }
+
+Configuration for bidirectional mode of voice+.
+
+#### Defined in
+
+[packages/touchpoint-ui/src/types.ts:202](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L202)
+
+## Variables
+
+### version
+
+• `Const` **version**: `string` = `packageJson.version`
+
+Package version
+
+#### Defined in
+
+[packages/touchpoint-ui/src/index.tsx:50](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L50)
 
 ## Functions
+
+### analyzePageForms
+
+▸ **analyzePageForms**(): [`PageForms`](#interfacespageformsmd)
+
+Analyze page forms
+
+#### Returns
+
+[`PageForms`](#interfacespageformsmd)
+
+pageForms
+
+#### Defined in
+
+[packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:71](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L71)
+
+___
+
+### Ripple
+
+▸ **Ripple**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.className?` | `string` | - |
+| `props.style?` | `CSSProperties` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+#### Returns
+
+`ReactNode`
+
+#### Defined in
+
+[packages/touchpoint-ui/src/components/Ripple.tsx:24](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/Ripple.tsx#L24)
+
+___
 
 ### Carousel
 
@@ -112,11 +217,11 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type        | Description                                                                                                                           |
-| :------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | `Object`    | -                                                                                                                                     |
-| `props.children`           | `ReactNode` | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`       | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -124,9 +229,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Carousel.tsx:5](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Carousel.tsx#L5)
+[packages/touchpoint-ui/src/components/ui/Carousel.tsx:5](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Carousel.tsx#L5)
 
----
+___
 
 ### CustomCard
 
@@ -134,10 +239,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type                                              | Description                                                                                                                           |
-| :------------------------- | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`CustomCardProps`](#interfacescustomcardpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                             | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`CustomCardProps`](#interfacescustomcardpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -145,9 +250,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:25](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L25)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L33)
 
----
+___
 
 ### CustomCardImageRow
 
@@ -155,12 +260,12 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type     | Description                                                                                                                           |
-| :------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | `Object` | -                                                                                                                                     |
-| `props.src`                | `string` | -                                                                                                                                     |
-| `props.alt?`               | `string` | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`    | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.src` | `string` | - |
+| `props.alt?` | `string` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -168,9 +273,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:44](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L44)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:76](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L76)
 
----
+___
 
 ### CustomCardRow
 
@@ -178,10 +283,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type                                                    | Description                                                                                                                           |
-| :------------------------- | :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`CustomCardRowProps`](#interfacescustomcardrowpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                                   | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`CustomCardRowProps`](#interfacescustomcardrowpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -189,9 +294,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:69](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L69)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:101](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L101)
 
----
+___
 
 ### DateInput
 
@@ -199,10 +304,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type                                            | Description                                                                                                                           |
-| :------------------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`DateInputProps`](#interfacesdateinputpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                           | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`DateInputProps`](#interfacesdateinputpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -210,9 +315,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/DateInput.tsx:25](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L25)
+[packages/touchpoint-ui/src/components/ui/DateInput.tsx:25](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L25)
 
----
+___
 
 ### IconButton
 
@@ -220,10 +325,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type                                              | Description                                                                                                                           |
-| :------------------------- | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconButtonProps`](#interfacesiconbuttonpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                             | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconButtonProps`](#interfacesiconbuttonpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -231,9 +336,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:67](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L67)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:94](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L94)
 
----
+___
 
 ### TextButton
 
@@ -241,10 +346,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type                                              | Description                                                                                                                           |
-| :------------------------- | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`TextButtonProps`](#interfacestextbuttonpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                             | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`TextButtonProps`](#interfacestextbuttonpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -252,9 +357,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/TextButton.tsx:33](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L33)
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:33](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L33)
 
----
+___
 
 ### BaseText
 
@@ -262,12 +367,12 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type        | Description                                                                                                                           |
-| :------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | `Object`    | -                                                                                                                                     |
-| `props.children`           | `ReactNode` | -                                                                                                                                     |
-| `props.faded?`             | `boolean`   | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`       | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `props.faded?` | `boolean` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -275,9 +380,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Typography.tsx:5](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Typography.tsx#L5)
+[packages/touchpoint-ui/src/components/ui/Typography.tsx:5](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Typography.tsx#L5)
 
----
+___
 
 ### SmallText
 
@@ -285,11 +390,11 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name                       | Type        | Description                                                                                                                           |
-| :------------------------- | :---------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | `Object`    | -                                                                                                                                     |
-| `props.children`           | `ReactNode` | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`       | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -297,9 +402,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Typography.tsx:16](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Typography.tsx#L16)
+[packages/touchpoint-ui/src/components/ui/Typography.tsx:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Typography.tsx#L16)
 
----
+___
 
 ### html
 
@@ -307,10 +412,10 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Parameters
 
-| Name        | Type                   |
-| :---------- | :--------------------- |
-| `strings`   | `TemplateStringsArray` |
-| `...values` | `any`[]                |
+| Name | Type |
+| :------ | :------ |
+| `strings` | `TemplateStringsArray` |
+| `...values` | `any`[] |
 
 #### Returns
 
@@ -318,9 +423,9 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 #### Defined in
 
-[packages/touchpoint-ui/src/index.tsx:33](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/index.tsx#L33)
+[packages/touchpoint-ui/src/index.tsx:59](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L59)
 
----
+___
 
 ### create
 
@@ -330,8 +435,8 @@ Creates a new Touchpoint UI instance and appends it to the document body
 
 #### Parameters
 
-| Name    | Type                                                              | Description                        |
-| :------ | :---------------------------------------------------------------- | :--------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `props` | [`TouchpointConfiguration`](#interfacestouchpointconfigurationmd) | Configuration props for Touchpoint |
 
 #### Returns
@@ -342,9 +447,9 @@ A promise that resolves to a TouchpointInstance
 
 #### Defined in
 
-[packages/touchpoint-ui/src/index.tsx:202](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/index.tsx#L202)
+[packages/touchpoint-ui/src/index.tsx:320](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L320)
 
----
+___
 
 ### PreviewContainer
 
@@ -352,13 +457,13 @@ A promise that resolves to a TouchpointInstance
 
 #### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | `Object`                                   | -                                                                                                                                     |
-| `props.children`           | `ReactNode`                                | -                                                                                                                                     |
-| `props.mode`               | [`ColorMode`](#colormode)                  | -                                                                                                                                     |
-| `props.theme`              | `Partial`\<[`Theme`](#interfacesthememd)\> | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | `Object` | - |
+| `props.children` | `ReactNode` | - |
+| `props.mode` | [`ColorMode`](#colormode) | - |
+| `props.theme` | `Partial`\<[`Theme`](#interfacesthememd)\> | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 #### Returns
 
@@ -366,11 +471,14 @@ A promise that resolves to a TouchpointInstance
 
 #### Defined in
 
-[packages/touchpoint-ui/src/preview.tsx:10](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/preview.tsx#L10)
+[packages/touchpoint-ui/src/preview.tsx:10](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/preview.tsx#L10)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
 
 <a name="interfacescustomcardpropsmd"></a>
 
@@ -388,9 +496,9 @@ Content to be rendered inside the card.
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:14](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L14)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:14](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L14)
 
----
+___
 
 #### selected
 
@@ -400,9 +508,9 @@ Whether the card is in a selected state. Used to highlight the card.
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:18](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L18)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L18)
 
----
+___
 
 #### onClick
 
@@ -420,7 +528,32 @@ Handler function for when the card is clicked
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:22](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L22)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L22)
+
+___
+
+#### href
+
+• `Optional` **href**: `string`
+
+Transform the card into an anchor tag with the href specified
+
+##### Defined in
+
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L26)
+
+___
+
+#### newTab
+
+• `Optional` **newTab**: `boolean`
+
+Specify whether the URL should take the user to a new tab
+
+##### Defined in
+
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L30)
+
 
 <a name="interfacescustomcardrowpropsmd"></a>
 
@@ -438,9 +571,9 @@ Content to be displayed on the left side of the row
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:58](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L58)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:90](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L90)
 
----
+___
 
 #### right
 
@@ -450,9 +583,9 @@ Content to be displayed on the right side of the row
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:62](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L62)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:94](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L94)
 
----
+___
 
 #### icon
 
@@ -462,7 +595,8 @@ Optional icon to be displayed in the center of the row
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:66](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L66)
+[packages/touchpoint-ui/src/components/ui/CustomCard.tsx:98](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/CustomCard.tsx#L98)
+
 
 <a name="interfacesdateinputpropsmd"></a>
 
@@ -484,8 +618,8 @@ Handler function called when the date is submitted
 
 ###### Parameters
 
-| Name   | Type     | Description                             |
-| :----- | :------- | :-------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `date` | `string` | The submitted date in YYYY-MM-DD format |
 
 ###### Returns
@@ -494,7 +628,8 @@ Handler function called when the date is submitted
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/DateInput.tsx:16](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L16)
+[packages/touchpoint-ui/src/components/ui/DateInput.tsx:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/DateInput.tsx#L16)
+
 
 <a name="interfacesiconbuttonpropsmd"></a>
 
@@ -520,9 +655,9 @@ Handler function called when the button is clicked
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:31](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L31)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:31](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L31)
 
----
+___
 
 #### label
 
@@ -532,9 +667,9 @@ Accessible label for the button
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:35](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L35)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:35](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L35)
 
----
+___
 
 #### className
 
@@ -544,9 +679,9 @@ Additional CSS classes to apply to the button
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:39](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L39)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:39](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L39)
 
----
+___
 
 #### type
 
@@ -556,9 +691,9 @@ Visual style variant of the button. One of IconButtonType.
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:43](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L43)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:43](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L43)
 
----
+___
 
 #### Icon
 
@@ -568,7 +703,8 @@ Icon component to display inside the button
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/IconButton.tsx:47](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L47)
+[packages/touchpoint-ui/src/components/ui/IconButton.tsx:47](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/IconButton.tsx#L47)
+
 
 <a name="interfacesiconsiconpropsmd"></a>
 
@@ -588,9 +724,9 @@ Additional CSS classes to apply to the icon
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:11](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L11)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:11](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L11)
 
----
+___
 
 #### size
 
@@ -600,7 +736,64 @@ Custom size in pixels for the icon
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:15](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L15)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:15](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L15)
+
+
+<a name="interfacesinteractiveelementinfomd"></a>
+
+## Interface: InteractiveElementInfo
+
+Accessibility information with ID
+
+### Hierarchy
+
+- [`AccessibilityInformation`](#accessibilityinformation)
+
+  ↳ **`InteractiveElementInfo`**
+
+### Properties
+
+#### id
+
+• **id**: `string`
+
+Form element ID (assigned by the analysis logic, not necessarily equal to the DOM ID)
+
+##### Defined in
+
+[packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:18](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L18)
+
+
+<a name="interfacespageformsmd"></a>
+
+## Interface: PageForms
+
+Page forms with elements
+
+### Properties
+
+#### context
+
+• **context**: [`InteractiveElementInfo`](#interfacesinteractiveelementinfomd)[]
+
+Page context
+
+##### Defined in
+
+[packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:28](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L28)
+
+___
+
+#### formElements
+
+• **formElements**: `Record`\<`string`, `Element`\>
+
+Form element references
+
+##### Defined in
+
+[packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts:32](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/bidirectional/analyzePageForms.ts#L32)
+
 
 <a name="interfacestextbuttonpropsmd"></a>
 
@@ -626,9 +819,9 @@ Handler function called when the button is clicked
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/TextButton.tsx:13](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L13)
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:13](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L13)
 
----
+___
 
 #### label
 
@@ -638,9 +831,9 @@ Text to display on the button
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/TextButton.tsx:17](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L17)
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L17)
 
----
+___
 
 #### className
 
@@ -650,22 +843,22 @@ Additional CSS classes to apply to the button
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/TextButton.tsx:21](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L21)
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:21](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L21)
 
----
+___
 
 #### type
 
-• `Optional` **type**: `"main"` \| `"ghost"`
+• `Optional` **type**: ``"main"`` \| ``"ghost"``
 
 Visual style variant of the button
 Default value is "ghost"
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/TextButton.tsx:26](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L26)
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L26)
 
----
+___
 
 #### Icon
 
@@ -675,7 +868,8 @@ Icon component to display inside the button.
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/TextButton.tsx:30](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L30)
+[packages/touchpoint-ui/src/components/ui/TextButton.tsx:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/TextButton.tsx#L30)
+
 
 <a name="interfacesthememd"></a>
 
@@ -693,9 +887,9 @@ Font family
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:61](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L61)
+[packages/touchpoint-ui/src/types.ts:66](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L66)
 
----
+___
 
 #### primary80
 
@@ -705,9 +899,9 @@ Primary color with 80% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:66](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L66)
+[packages/touchpoint-ui/src/types.ts:71](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L71)
 
----
+___
 
 #### primary60
 
@@ -717,9 +911,9 @@ Primary color with 60% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:70](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L70)
+[packages/touchpoint-ui/src/types.ts:75](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L75)
 
----
+___
 
 #### primary40
 
@@ -729,9 +923,9 @@ Primary color with 40% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:74](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L74)
+[packages/touchpoint-ui/src/types.ts:79](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L79)
 
----
+___
 
 #### primary20
 
@@ -741,9 +935,9 @@ Primary color with 20% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:78](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L78)
+[packages/touchpoint-ui/src/types.ts:83](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L83)
 
----
+___
 
 #### primary10
 
@@ -753,9 +947,9 @@ Primary color with 10% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:82](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L82)
+[packages/touchpoint-ui/src/types.ts:87](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L87)
 
----
+___
 
 #### primary5
 
@@ -765,9 +959,9 @@ Primary color with 5% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:86](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L86)
+[packages/touchpoint-ui/src/types.ts:91](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L91)
 
----
+___
 
 #### primary1
 
@@ -777,9 +971,9 @@ Primary color with 1% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:90](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L90)
+[packages/touchpoint-ui/src/types.ts:95](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L95)
 
----
+___
 
 #### secondary80
 
@@ -789,9 +983,9 @@ Secondary color with 80% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:95](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L95)
+[packages/touchpoint-ui/src/types.ts:100](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L100)
 
----
+___
 
 #### secondary60
 
@@ -801,9 +995,9 @@ Secondary color with 60% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:99](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L99)
+[packages/touchpoint-ui/src/types.ts:104](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L104)
 
----
+___
 
 #### secondary40
 
@@ -813,9 +1007,9 @@ Secondary color with 40% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:103](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L103)
+[packages/touchpoint-ui/src/types.ts:108](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L108)
 
----
+___
 
 #### secondary20
 
@@ -825,9 +1019,9 @@ Secondary color with 20% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:107](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L107)
+[packages/touchpoint-ui/src/types.ts:112](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L112)
 
----
+___
 
 #### secondary10
 
@@ -837,9 +1031,9 @@ Secondary color with 10% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:111](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L111)
+[packages/touchpoint-ui/src/types.ts:116](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L116)
 
----
+___
 
 #### secondary5
 
@@ -849,9 +1043,9 @@ Secondary color with 5% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:115](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L115)
+[packages/touchpoint-ui/src/types.ts:120](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L120)
 
----
+___
 
 #### secondary1
 
@@ -861,9 +1055,9 @@ Secondary color with 1% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:119](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L119)
+[packages/touchpoint-ui/src/types.ts:124](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L124)
 
----
+___
 
 #### accent
 
@@ -873,9 +1067,9 @@ Accent color used e.g. for prominent buttons, the loader animation as well as se
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:124](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L124)
+[packages/touchpoint-ui/src/types.ts:129](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L129)
 
----
+___
 
 #### accent20
 
@@ -885,9 +1079,9 @@ Accent color with 20% opacity
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:128](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L128)
+[packages/touchpoint-ui/src/types.ts:133](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L133)
 
----
+___
 
 #### background
 
@@ -897,9 +1091,9 @@ The background color of the main Touchpoint interface
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:132](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L132)
+[packages/touchpoint-ui/src/types.ts:137](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L137)
 
----
+___
 
 #### overlay
 
@@ -909,9 +1103,9 @@ The color of the overlay covering the visible portion of the website when the To
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:136](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L136)
+[packages/touchpoint-ui/src/types.ts:141](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L141)
 
----
+___
 
 #### warningPrimary
 
@@ -921,9 +1115,9 @@ Primary warning color
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:141](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L141)
+[packages/touchpoint-ui/src/types.ts:146](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L146)
 
----
+___
 
 #### warningSecondary
 
@@ -933,9 +1127,9 @@ Secondary warning color
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:145](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L145)
+[packages/touchpoint-ui/src/types.ts:150](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L150)
 
----
+___
 
 #### errorPrimary
 
@@ -945,9 +1139,9 @@ Primary error color
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:149](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L149)
+[packages/touchpoint-ui/src/types.ts:154](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L154)
 
----
+___
 
 #### errorSecondary
 
@@ -957,9 +1151,9 @@ Secondary error color
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:153](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L153)
+[packages/touchpoint-ui/src/types.ts:158](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L158)
 
----
+___
 
 #### innerBorderRadius
 
@@ -969,9 +1163,9 @@ Inner border radius: used for most buttons
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:158](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L158)
+[packages/touchpoint-ui/src/types.ts:163](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L163)
 
----
+___
 
 #### outerBorderRadius
 
@@ -981,7 +1175,8 @@ Outer border radius: generally used for elements that contain buttons that have 
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:162](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L162)
+[packages/touchpoint-ui/src/types.ts:167](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L167)
+
 
 <a name="interfacestouchpointconfigurationmd"></a>
 
@@ -999,9 +1194,9 @@ Connection information for the @nlxai/chat-core conversation handler
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:178](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L178)
+[packages/touchpoint-ui/src/types.ts:289](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L289)
 
----
+___
 
 #### windowSize
 
@@ -1011,9 +1206,9 @@ Optional window size for the chat window, defaults to `half`
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:182](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L182)
+[packages/touchpoint-ui/src/types.ts:293](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L293)
 
----
+___
 
 #### colorMode
 
@@ -1023,9 +1218,9 @@ Optional color mode for the chat window, defaults to `dark`
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:186](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L186)
+[packages/touchpoint-ui/src/types.ts:297](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L297)
 
----
+___
 
 #### brandIcon
 
@@ -1035,13 +1230,13 @@ URL of icon used to display the brand in the chat header
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:190](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L190)
+[packages/touchpoint-ui/src/types.ts:301](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L301)
 
----
+___
 
 #### launchIcon
 
-• `Optional` **launchIcon**: `string` \| `boolean`
+• `Optional` **launchIcon**: `string` \| `boolean` \| [`CustomLaunchButton`](#customlaunchbutton)
 
 URL of icon used on the launch icon in the bottom right when the experience is collapsed.
 
@@ -1049,9 +1244,9 @@ When set to `false`, no launch button is shown at all. When not set or set to `t
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:196](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L196)
+[packages/touchpoint-ui/src/types.ts:307](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L307)
 
----
+___
 
 #### userMessageBubble
 
@@ -1061,9 +1256,9 @@ Specifies whether the user message has bubbles or not
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:200](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L200)
+[packages/touchpoint-ui/src/types.ts:311](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L311)
 
----
+___
 
 #### agentMessageBubble
 
@@ -1073,9 +1268,9 @@ Specifies whether the agent message has bubbles or not
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:204](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L204)
+[packages/touchpoint-ui/src/types.ts:315](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L315)
 
----
+___
 
 #### chatMode
 
@@ -1085,9 +1280,9 @@ Enables chat mode, a classic chat experience with inline loaders and the chat hi
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:208](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L208)
+[packages/touchpoint-ui/src/types.ts:319](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L319)
 
----
+___
 
 #### theme
 
@@ -1097,21 +1292,21 @@ Optional theme object to override default theme values
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:212](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L212)
+[packages/touchpoint-ui/src/types.ts:323](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L323)
 
----
+___
 
 #### customModalities
 
-• `Optional` **customModalities**: `Record`\<`string`, [`CustomModalityComponent`](#custommodalitycomponent)\<`any`\>\>
+• `Optional` **customModalities**: `Record`\<`string`, [`CustomModalityComponent`](#custommodalitycomponent)\<`unknown`\>\>
 
 Optional custom modality components to render in Touchpoint
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:216](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L216)
+[packages/touchpoint-ui/src/types.ts:327](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L327)
 
----
+___
 
 #### initializeConversation
 
@@ -1123,21 +1318,50 @@ Custom conversation init method. Defaults to sending the welcome intent
 
 the conversation handler.
 
+**`Param`**
+
+the context object
+
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:221](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L221)
+[packages/touchpoint-ui/src/types.ts:333](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L333)
 
----
+___
 
 #### input
 
-• `Optional` **input**: `"text"` \| `"voice"` \| `"voiceMini"`
+• `Optional` **input**: [`Input`](#input)
 
-Controls the ways in which the user can communicate with the application. Defaults to `"text"`
+Controls the ways in which  the user can communicate with the application. Defaults to `"text"`
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/types.ts:225](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/types.ts#L225)
+[packages/touchpoint-ui/src/types.ts:337](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L337)
+
+___
+
+#### initialContext
+
+• `Optional` **initialContext**: `Context`
+
+Context sent with the initial request.
+
+##### Defined in
+
+[packages/touchpoint-ui/src/types.ts:341](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L341)
+
+___
+
+#### bidirectional
+
+• `Optional` **bidirectional**: [`BidirectionalConfig`](#bidirectionalconfig)
+
+Enables bidirectional mode of voice+. Will automatically set the bidirectional flag in the config.
+
+##### Defined in
+
+[packages/touchpoint-ui/src/types.ts:347](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/types.ts#L347)
+
 
 <a name="interfacestouchpointinstancemd"></a>
 
@@ -1155,9 +1379,9 @@ Controls whether the Touchpoint UI is expanded or collapsed
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/index.tsx:186](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/index.tsx#L186)
+[packages/touchpoint-ui/src/index.tsx:304](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L304)
 
----
+___
 
 #### conversationHandler
 
@@ -1167,9 +1391,9 @@ The conversation handler instance for interacting with the application
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/index.tsx:190](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/index.tsx#L190)
+[packages/touchpoint-ui/src/index.tsx:308](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L308)
 
----
+___
 
 #### teardown
 
@@ -1187,9 +1411,10 @@ Method to remove the Touchpoint UI from the DOM
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/index.tsx:194](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/index.tsx#L194)
+[packages/touchpoint-ui/src/index.tsx:312](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/index.tsx#L312)
 
 # Modules
+
 
 <a name="modulesiconsmd"></a>
 
@@ -1209,7 +1434,7 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:21](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L21)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:21](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L21)
 
 ### Functions
 
@@ -1219,10 +1444,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1230,9 +1455,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:29](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L29)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:29](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L29)
 
----
+___
 
 #### Touchpoint
 
@@ -1240,10 +1465,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1251,9 +1476,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:40](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L40)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:40](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L40)
 
----
+___
 
 #### AssistantOld
 
@@ -1261,10 +1486,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1272,9 +1497,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:67](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L67)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:67](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L67)
 
----
+___
 
 #### Add
 
@@ -1282,10 +1507,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1293,9 +1518,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:78](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L78)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:78](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L78)
 
----
+___
 
 #### ArrowDown
 
@@ -1303,10 +1528,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1314,9 +1539,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:86](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L86)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:86](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L86)
 
----
+___
 
 #### ArrowLeft
 
@@ -1324,10 +1549,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1335,9 +1560,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:97](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L97)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:97](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L97)
 
----
+___
 
 #### ArrowRight
 
@@ -1345,10 +1570,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1356,9 +1581,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:108](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L108)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:108](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L108)
 
----
+___
 
 #### ArrowUp
 
@@ -1366,10 +1591,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1377,9 +1602,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:119](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L119)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:119](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L119)
 
----
+___
 
 #### ArrowForward
 
@@ -1387,10 +1612,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1398,9 +1623,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:130](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L130)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:130](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L130)
 
----
+___
 
 #### Attachment
 
@@ -1408,10 +1633,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1419,9 +1644,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:141](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L141)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:141](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L141)
 
----
+___
 
 #### Camera
 
@@ -1429,10 +1654,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1440,9 +1665,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:152](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L152)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:152](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L152)
 
----
+___
 
 #### Check
 
@@ -1450,10 +1675,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1461,9 +1686,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:167](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L167)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:167](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L167)
 
----
+___
 
 #### Close
 
@@ -1471,10 +1696,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1482,9 +1707,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:178](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L178)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:178](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L178)
 
----
+___
 
 #### Copy
 
@@ -1492,10 +1717,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1503,9 +1728,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:189](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L189)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:189](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L189)
 
----
+___
 
 #### Date
 
@@ -1513,10 +1738,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1524,9 +1749,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:200](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L200)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:200](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L200)
 
----
+___
 
 #### Delete
 
@@ -1534,10 +1759,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1545,9 +1770,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:211](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L211)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:211](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L211)
 
----
+___
 
 #### Escalate
 
@@ -1555,10 +1780,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1566,9 +1791,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:225](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L225)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:225](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L225)
 
----
+___
 
 #### Error
 
@@ -1576,10 +1801,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1587,9 +1812,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:248](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L248)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:248](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L248)
 
----
+___
 
 #### FullScreen
 
@@ -1597,10 +1822,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1608,9 +1833,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:259](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L259)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:259](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L259)
 
----
+___
 
 #### Mic
 
@@ -1618,10 +1843,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1629,9 +1854,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:270](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L270)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:270](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L270)
 
----
+___
 
 #### MicOff
 
@@ -1639,10 +1864,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1650,9 +1875,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:281](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L281)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:281](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L281)
 
----
+___
 
 #### Location
 
@@ -1660,10 +1885,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1671,9 +1896,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:292](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L292)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:292](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L292)
 
----
+___
 
 #### Volume
 
@@ -1681,10 +1906,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1692,9 +1917,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:303](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L303)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:303](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L303)
 
----
+___
 
 #### VolumeOff
 
@@ -1702,10 +1927,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1713,9 +1938,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:314](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L314)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:314](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L314)
 
----
+___
 
 #### Translate
 
@@ -1723,10 +1948,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1734,9 +1959,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:325](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L325)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:325](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L325)
 
----
+___
 
 #### OpenInNew
 
@@ -1744,10 +1969,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1755,9 +1980,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:336](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L336)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:336](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L336)
 
----
+___
 
 #### Play
 
@@ -1765,10 +1990,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1776,9 +2001,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:347](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L347)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:347](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L347)
 
----
+___
 
 #### Preview
 
@@ -1786,10 +2011,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1797,9 +2022,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:355](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L355)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:355](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L355)
 
----
+___
 
 #### Reorder
 
@@ -1807,10 +2032,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1818,9 +2043,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:372](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L372)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:372](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L372)
 
----
+___
 
 #### Restart
 
@@ -1828,10 +2053,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1839,9 +2064,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:383](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L383)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:383](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L383)
 
----
+___
 
 #### Settings
 
@@ -1849,10 +2074,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1860,9 +2085,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:394](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L394)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:394](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L394)
 
----
+___
 
 #### Search
 
@@ -1870,10 +2095,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1881,9 +2106,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:405](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L405)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:405](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L405)
 
----
+___
 
 #### Share
 
@@ -1891,10 +2116,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1902,9 +2127,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:416](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L416)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:416](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L416)
 
----
+___
 
 #### Warning
 
@@ -1912,10 +2137,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1923,9 +2148,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:427](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L427)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:427](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L427)
 
----
+___
 
 #### ThumbDown
 
@@ -1933,10 +2158,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1944,9 +2169,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:438](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L438)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:438](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L438)
 
----
+___
 
 #### ThumbUp
 
@@ -1954,10 +2179,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1965,9 +2190,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:449](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L449)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:449](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L449)
 
----
+___
 
 #### Time
 
@@ -1975,10 +2200,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -1986,9 +2211,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:460](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L460)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:460](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L460)
 
----
+___
 
 #### Undo
 
@@ -1996,10 +2221,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2007,9 +2232,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:477](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L477)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:477](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L477)
 
----
+___
 
 #### Refresh
 
@@ -2017,10 +2242,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2028,9 +2253,9 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:488](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L488)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:488](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L488)
 
----
+___
 
 #### Help
 
@@ -2038,10 +2263,10 @@ Type definition for an icon component
 
 ##### Parameters
 
-| Name                       | Type                                       | Description                                                                                                                           |
-| :------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| `props`                    | [`IconProps`](#interfacesiconsiconpropsmd) | -                                                                                                                                     |
-| `deprecatedLegacyContext?` | `any`                                      | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
 
 ##### Returns
 
@@ -2049,4 +2274,25 @@ Type definition for an icon component
 
 ##### Defined in
 
-[packages/touchpoint-ui/src/components/ui/Icons.tsx:499](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/touchpoint-ui/src/components/ui/Icons.tsx#L499)
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:499](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L499)
+
+___
+
+#### OpenLink
+
+▸ **OpenLink**(`props`, `deprecatedLegacyContext?`): `ReactNode`
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`IconProps`](#interfacesiconsiconpropsmd) | - |
+| `deprecatedLegacyContext?` | `any` | **`Deprecated`** **`See`** [React Docs](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods) |
+
+##### Returns
+
+`ReactNode`
+
+##### Defined in
+
+[packages/touchpoint-ui/src/components/ui/Icons.tsx:510](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/touchpoint-ui/src/components/ui/Icons.tsx#L510)

--- a/packages/website/src/content/voice-plus-api-reference.md
+++ b/packages/website/src/content/voice-plus-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/voice-plus-core
@@ -18,8 +17,8 @@ The starting point of the package. Call create to create a Voice+ client.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type                            | Description                          |
+| :-------- | :------------------------------ | :----------------------------------- |
 | `options` | [`Config`](#interfacesconfigmd) | configuration options for the client |
 
 #### Returns
@@ -31,14 +30,14 @@ a Voice+ client
 **`Example`**
 
 ```typescript
- const client = nlxai.voicePlus.create({
- // hard-coded params
- apiKey: "REPLACE_WITH_API_KEY",
- workspaceId: "REPLACE_WITH_WORKSPACE_ID",
- scriptId: "REPLACE_WITH_SCRIPT_ID",
- // dynamic params
- conversationId: "REPLACE_WITH_CONVERSATION_ID",
- languageCode: "en-US",
+const client = nlxai.voicePlus.create({
+  // hard-coded params
+  apiKey: "REPLACE_WITH_API_KEY",
+  workspaceId: "REPLACE_WITH_WORKSPACE_ID",
+  scriptId: "REPLACE_WITH_SCRIPT_ID",
+  // dynamic params
+  conversationId: "REPLACE_WITH_CONVERSATION_ID",
+  languageCode: "en-US",
 });
 
 client.sendStep("REPLACE_WITH_STEP_ID");
@@ -48,7 +47,7 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 [index.ts:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L26)
 
-___
+---
 
 ## Client
 
@@ -66,7 +65,7 @@ ___
 
 ### StepInfo
 
-Ƭ **StepInfo**: `string` \| \{ `stepId`: `string` ; `stepTriggerDescription?`: `string`  }
+Ƭ **StepInfo**: `string` \| \{ `stepId`: `string` ; `stepTriggerDescription?`: `string` }
 
 Step information, either a step ID as a single string or an object
 
@@ -74,12 +73,9 @@ Step information, either a step ID as a single string or an object
 
 [index.ts:95](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L95)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfacesclientmd"></a>
 
@@ -96,18 +92,19 @@ The Voice+ client
 **`Example`**
 
 ```typescript
- const client = nlxai.voicePlus.create({
- // hard-coded params
- apiKey: "REPLACE_WITH_API_KEY",
- workspaceId: "REPLACE_WITH_WORKSPACE_ID",
- scriptId: "REPLACE_WITH_SCRIPT_ID",
- // dynamic params
- conversationId: "REPLACE_WITH_CONVERSATION_ID",
- languageCode: "en-US",
+const client = nlxai.voicePlus.create({
+  // hard-coded params
+  apiKey: "REPLACE_WITH_API_KEY",
+  workspaceId: "REPLACE_WITH_WORKSPACE_ID",
+  scriptId: "REPLACE_WITH_SCRIPT_ID",
+  // dynamic params
+  conversationId: "REPLACE_WITH_CONVERSATION_ID",
+  languageCode: "en-US",
 });
 
-client.sendStep("REPLACE_WITH_STEP_ID", {selectedSeat: "4a"});
+client.sendStep("REPLACE_WITH_STEP_ID", { selectedSeat: "4a" });
 ```
+
 sends a step to the voice bot
 
 ##### Type declaration
@@ -116,10 +113,10 @@ sends a step to the voice bot
 
 ###### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `step` | [`StepInfo`](#stepinfo) | the next step to transition to, either a UUID as string or an object containing stepId. _Note: The step ID must be a valid UUID_ |
-| `context?` | [`Context`](#context) | [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent. |
+| Name       | Type                    | Description                                                                                                                                                              |
+| :--------- | :---------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `step`     | [`StepInfo`](#stepinfo) | the next step to transition to, either a UUID as string or an object containing stepId. _Note: The step ID must be a valid UUID_                                         |
+| `context?` | [`Context`](#context)   | [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent. |
 
 ###### Returns
 
@@ -128,7 +125,6 @@ sends a step to the voice bot
 ##### Defined in
 
 [index.ts:136](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L136)
-
 
 <a name="interfacesconfigmd"></a>
 
@@ -142,13 +138,13 @@ Initial configuration used when creating a journey manager
 
 • **apiKey**: `string`
 
-* the API key generated for the journey.
+- the API key generated for the journey.
 
 ##### Defined in
 
 [index.ts:151](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L151)
 
-___
+---
 
 #### journeyId
 
@@ -164,7 +160,7 @@ use `scriptId` instead
 
 [index.ts:156](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L156)
 
-___
+---
 
 #### scriptId
 
@@ -176,7 +172,7 @@ the ID of the script.
 
 [index.ts:158](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L158)
 
-___
+---
 
 #### workspaceId
 
@@ -188,7 +184,7 @@ your workspace id
 
 [index.ts:161](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L161)
 
-___
+---
 
 #### conversationId
 
@@ -202,7 +198,7 @@ _Note: This must be dynamically set by the voice bot._
 
 [index.ts:168](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L168)
 
-___
+---
 
 #### languageCode
 
@@ -214,7 +210,7 @@ the user's language code, consistent with the language codes defined on the jour
 
 [index.ts:173](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L173)
 
-___
+---
 
 #### debug
 

--- a/packages/website/src/content/voice-plus-api-reference.md
+++ b/packages/website/src/content/voice-plus-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/voice-plus-core
@@ -17,8 +18,8 @@ The starting point of the package. Call create to create a Voice+ client.
 
 #### Parameters
 
-| Name      | Type                            | Description                          |
-| :-------- | :------------------------------ | :----------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `options` | [`Config`](#interfacesconfigmd) | configuration options for the client |
 
 #### Returns
@@ -30,14 +31,14 @@ a Voice+ client
 **`Example`**
 
 ```typescript
-const client = nlxai.voicePlus.create({
-  // hard-coded params
-  apiKey: "REPLACE_WITH_API_KEY",
-  workspaceId: "REPLACE_WITH_WORKSPACE_ID",
-  scriptId: "REPLACE_WITH_SCRIPT_ID",
-  // dynamic params
-  conversationId: "REPLACE_WITH_CONVERSATION_ID",
-  languageCode: "en-US",
+ const client = nlxai.voicePlus.create({
+ // hard-coded params
+ apiKey: "REPLACE_WITH_API_KEY",
+ workspaceId: "REPLACE_WITH_WORKSPACE_ID",
+ scriptId: "REPLACE_WITH_SCRIPT_ID",
+ // dynamic params
+ conversationId: "REPLACE_WITH_CONVERSATION_ID",
+ languageCode: "en-US",
 });
 
 client.sendStep("REPLACE_WITH_STEP_ID");
@@ -45,9 +46,9 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 #### Defined in
 
-[index.ts:26](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L26)
+[index.ts:26](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L26)
 
----
+___
 
 ## Client
 
@@ -59,23 +60,26 @@ client.sendStep("REPLACE_WITH_STEP_ID");
 
 #### Defined in
 
-[index.ts:143](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L143)
+[index.ts:143](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L143)
 
 ## Other
 
 ### StepInfo
 
-Ƭ **StepInfo**: `string` \| \{ `stepId`: `string` ; `stepTriggerDescription?`: `string` }
+Ƭ **StepInfo**: `string` \| \{ `stepId`: `string` ; `stepTriggerDescription?`: `string`  }
 
 Step information, either a step ID as a single string or an object
 
 #### Defined in
 
-[index.ts:95](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L95)
+[index.ts:95](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L95)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
 
 <a name="interfacesclientmd"></a>
 
@@ -92,19 +96,18 @@ The Voice+ client
 **`Example`**
 
 ```typescript
-const client = nlxai.voicePlus.create({
-  // hard-coded params
-  apiKey: "REPLACE_WITH_API_KEY",
-  workspaceId: "REPLACE_WITH_WORKSPACE_ID",
-  scriptId: "REPLACE_WITH_SCRIPT_ID",
-  // dynamic params
-  conversationId: "REPLACE_WITH_CONVERSATION_ID",
-  languageCode: "en-US",
+ const client = nlxai.voicePlus.create({
+ // hard-coded params
+ apiKey: "REPLACE_WITH_API_KEY",
+ workspaceId: "REPLACE_WITH_WORKSPACE_ID",
+ scriptId: "REPLACE_WITH_SCRIPT_ID",
+ // dynamic params
+ conversationId: "REPLACE_WITH_CONVERSATION_ID",
+ languageCode: "en-US",
 });
 
-client.sendStep("REPLACE_WITH_STEP_ID", { selectedSeat: "4a" });
+client.sendStep("REPLACE_WITH_STEP_ID", {selectedSeat: "4a"});
 ```
-
 sends a step to the voice bot
 
 ##### Type declaration
@@ -113,10 +116,10 @@ sends a step to the voice bot
 
 ###### Parameters
 
-| Name       | Type                    | Description                                                                                                                                                              |
-| :--------- | :---------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `step`     | [`StepInfo`](#stepinfo) | the next step to transition to, either a UUID as string or an object containing stepId. _Note: The step ID must be a valid UUID_                                         |
-| `context?` | [`Context`](#context)   | [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent. |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `step` | [`StepInfo`](#stepinfo) | the next step to transition to, either a UUID as string or an object containing stepId. _Note: The step ID must be a valid UUID_ |
+| `context?` | [`Context`](#context) | [context](https://docs.studio.nlx.ai/workspacesettings/documentation-settings/settings-context-attributes) to send back to the voice bot, for usage later in the intent. |
 
 ###### Returns
 
@@ -124,7 +127,8 @@ sends a step to the voice bot
 
 ##### Defined in
 
-[index.ts:136](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L136)
+[index.ts:136](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L136)
+
 
 <a name="interfacesconfigmd"></a>
 
@@ -138,13 +142,13 @@ Initial configuration used when creating a journey manager
 
 • **apiKey**: `string`
 
-- the API key generated for the journey.
+* the API key generated for the journey.
 
 ##### Defined in
 
-[index.ts:151](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L151)
+[index.ts:151](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L151)
 
----
+___
 
 #### journeyId
 
@@ -158,9 +162,9 @@ use `scriptId` instead
 
 ##### Defined in
 
-[index.ts:156](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L156)
+[index.ts:156](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L156)
 
----
+___
 
 #### scriptId
 
@@ -170,9 +174,9 @@ the ID of the script.
 
 ##### Defined in
 
-[index.ts:158](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L158)
+[index.ts:158](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L158)
 
----
+___
 
 #### workspaceId
 
@@ -182,9 +186,9 @@ your workspace id
 
 ##### Defined in
 
-[index.ts:161](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L161)
+[index.ts:161](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L161)
 
----
+___
 
 #### conversationId
 
@@ -196,9 +200,9 @@ _Note: This must be dynamically set by the voice bot._
 
 ##### Defined in
 
-[index.ts:168](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L168)
+[index.ts:168](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L168)
 
----
+___
 
 #### languageCode
 
@@ -208,9 +212,9 @@ the user's language code, consistent with the language codes defined on the jour
 
 ##### Defined in
 
-[index.ts:173](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L173)
+[index.ts:173](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L173)
 
----
+___
 
 #### debug
 
@@ -220,4 +224,4 @@ set to true to help debug issues or errors. Defaults to false
 
 ##### Defined in
 
-[index.ts:176](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/voice-plus-core/src/index.ts#L176)
+[index.ts:176](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/voice-plus-core/src/index.ts#L176)

--- a/packages/website/src/content/web-widget-api-reference.md
+++ b/packages/website/src/content/web-widget-api-reference.md
@@ -1,3 +1,4 @@
+
 <a name="readmemd"></a>
 
 # @nlxai/chat-widget
@@ -15,7 +16,7 @@
 
 ### StorageType
 
-Ƭ **StorageType**: `"localStorage"` \| `"sessionStorage"`
+Ƭ **StorageType**: ``"localStorage"`` \| ``"sessionStorage"``
 
 When this option is set to `"localStorage"` or `"sessionStorage"`,
 the state of the chat conversation is persisted in [local](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
@@ -30,20 +31,26 @@ full page refreshes.
 
 #### Defined in
 
-[packages/chat-widget/src/props.ts:45](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L45)
+[packages/chat-widget/src/props.ts:45](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L45)
 
----
+___
 
 ### CustomModalityComponent
 
-Ƭ **CustomModalityComponent**: `FC`\<\{ `key`: `string` ; `data`: `any` }\>
+Ƭ **CustomModalityComponent**\<`T`\>: `ComponentType`\<\{ `key`: `string` ; `data`: `T` ; `conversationHandler`: `ConversationHandler`  }\>
 
 Custom Modalities allow rendering of rich components from nodes.
 See: https://docs.studio.nlx.ai/build/resources/modalities
 
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | `unknown` |
+
 #### Defined in
 
-[packages/chat-widget/src/props.ts:51](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L51)
+[packages/chat-widget/src/props.ts:51](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L51)
 
 ## Variables
 
@@ -55,33 +62,33 @@ the default theme
 
 #### Defined in
 
-[packages/chat-widget/src/ui/constants.ts:16](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/ui/constants.ts#L16)
+[packages/chat-widget/src/ui/constants.ts:16](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/ui/constants.ts#L16)
 
 ## Functions
 
 ### getCurrentExpirationTimestamp
 
-▸ **getCurrentExpirationTimestamp**(`responses`): `null` \| `number`
+▸ **getCurrentExpirationTimestamp**(`responses`): ``null`` \| `number`
 
 Get current expiration timestamp from the current list of reponses
 
 #### Parameters
 
-| Name        | Type         | Description                                                                           |
-| :---------- | :----------- | :------------------------------------------------------------------------------------ |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `responses` | `Response`[] | the current list of user and bot responses (first argument in the subscribe callback) |
 
 #### Returns
 
-`null` \| `number`
+``null`` \| `number`
 
 an expiration timestamp in Unix Epoch (`new Date().getTime()`), or `null` if this is not known (typically occurs if the bot has not responded yet)
 
 #### Defined in
 
-packages/chat-core/lib/index.d.ts:661
+packages/chat-core/lib/index.d.ts:735
 
----
+___
 
 ### create
 
@@ -91,8 +98,8 @@ Create a new chat widget and renders it as the last element in the body.
 
 #### Parameters
 
-| Name    | Type                          |
-| :------ | :---------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `props` | [`Props`](#interfacespropsmd) |
 
 #### Returns
@@ -103,9 +110,9 @@ the WidgetInstance to script widget behavior.
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:114](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L114)
+[packages/chat-widget/src/index.tsx:114](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L114)
 
----
+___
 
 ### clearSession
 
@@ -115,8 +122,8 @@ Clears stored session history.
 
 #### Parameters
 
-| Name      | Type                          | Description                 |
-| :-------- | :---------------------------- | :-------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `storeIn` | [`StorageType`](#storagetype) | where to clear the session. |
 
 #### Returns
@@ -125,13 +132,13 @@ Clears stored session history.
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:351](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L351)
+[packages/chat-widget/src/index.tsx:357](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L357)
 
----
+___
 
 ### useConversationHandler
 
-▸ **useConversationHandler**(): `null` \| `ConversationHandler`
+▸ **useConversationHandler**(): ``null`` \| `ConversationHandler`
 
 Hook to get the ConversationHandler for the widget.
 This may be called before the Widget has been created.
@@ -139,15 +146,15 @@ It will return null until the Widget has been created and the conversation has b
 
 #### Returns
 
-`null` \| `ConversationHandler`
+``null`` \| `ConversationHandler`
 
 the ConversationHandler if the widget has been created and its conversation has been established, otherwise it returns null.
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:474](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L474)
+[packages/chat-widget/src/index.tsx:480](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L480)
 
----
+___
 
 ### Widget
 
@@ -155,8 +162,8 @@ the ConversationHandler if the widget has been created and its conversation has 
 
 #### Parameters
 
-| Name    | Type                                                                                     |
-| :------ | :--------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `props` | [`Props`](#interfacespropsmd) & `RefAttributes`\<[`WidgetRef`](#interfaceswidgetrefmd)\> |
 
 #### Returns
@@ -165,11 +172,14 @@ the ConversationHandler if the widget has been created and its conversation has 
 
 #### Defined in
 
-[packages/chat-widget/src/index.tsx:478](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L478)
+[packages/chat-widget/src/index.tsx:484](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L484)
+
 
 <a name="indexmd"></a>
 
+
 # Interfaces
+
 
 <a name="interfacesnudgemd"></a>
 
@@ -191,9 +201,9 @@ The text content of the nudge. Markdown is supported.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:73](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L73)
+[packages/chat-widget/src/props.ts:78](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L78)
 
----
+___
 
 #### showAfter
 
@@ -204,9 +214,9 @@ Defaults to 3000 (3s) if not set.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:78](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L78)
+[packages/chat-widget/src/props.ts:83](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L83)
 
----
+___
 
 #### hideAfter
 
@@ -217,7 +227,8 @@ Defaults to 20000 (20s) if not set.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:83](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L83)
+[packages/chat-widget/src/props.ts:88](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L88)
+
 
 <a name="interfacespropsmd"></a>
 
@@ -235,9 +246,9 @@ The configuration to create a conversation.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:93](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L93)
+[packages/chat-widget/src/props.ts:98](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L98)
 
----
+___
 
 #### theme
 
@@ -247,9 +258,9 @@ The theme to apply to the chat widget.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:97](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L97)
+[packages/chat-widget/src/props.ts:102](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L102)
 
----
+___
 
 #### titleBar
 
@@ -259,9 +270,9 @@ How to configure the title bar. When missing, the widget will not have a title b
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:101](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L101)
+[packages/chat-widget/src/props.ts:106](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L106)
 
----
+___
 
 #### chatIcon
 
@@ -271,9 +282,9 @@ If you want a custom chat icon, set this to the URL of an image to use.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:105](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L105)
+[packages/chat-widget/src/props.ts:110](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L110)
 
----
+___
 
 #### nudge
 
@@ -283,9 +294,9 @@ An optional [Nudge](#interfacesnudgemd) configuration object.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:109](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L109)
+[packages/chat-widget/src/props.ts:114](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L114)
 
----
+___
 
 #### inputPlaceholder
 
@@ -295,9 +306,9 @@ The placeholder in the input field. When not set, the default placeholder is "Ty
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:113](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L113)
+[packages/chat-widget/src/props.ts:118](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L118)
 
----
+___
 
 #### loaderMessage
 
@@ -307,9 +318,9 @@ A message to display to the user while the bot is still processing the previous 
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:117](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L117)
+[packages/chat-widget/src/props.ts:122](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L122)
 
----
+___
 
 #### showLoaderMessageAfter
 
@@ -319,9 +330,9 @@ How long to wait, in milliseconds, before the loader message is displayed. Defau
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:121](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L121)
+[packages/chat-widget/src/props.ts:126](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L126)
 
----
+___
 
 #### allowChoiceReselection
 
@@ -331,9 +342,9 @@ If set to true, previously selected choices in the chat can be changed.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:125](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L125)
+[packages/chat-widget/src/props.ts:130](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L130)
 
----
+___
 
 #### storeIn
 
@@ -343,9 +354,9 @@ When set, chat history & conversation will be stored in the browser.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:129](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L129)
+[packages/chat-widget/src/props.ts:134](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L134)
 
----
+___
 
 #### onExpand
 
@@ -359,8 +370,8 @@ Optional callback to be called when the chat is expanded.
 
 ###### Parameters
 
-| Name                  | Type                  |
-| :-------------------- | :-------------------- |
+| Name | Type |
+| :------ | :------ |
 | `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
@@ -369,9 +380,9 @@ Optional callback to be called when the chat is expanded.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:133](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L133)
+[packages/chat-widget/src/props.ts:138](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L138)
 
----
+___
 
 #### onCollapse
 
@@ -385,8 +396,8 @@ Optional callback to be called when the chat is collapsed. This is also called w
 
 ###### Parameters
 
-| Name                  | Type                  |
-| :-------------------- | :-------------------- |
+| Name | Type |
+| :------ | :------ |
 | `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
@@ -395,9 +406,9 @@ Optional callback to be called when the chat is collapsed. This is also called w
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:137](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L137)
+[packages/chat-widget/src/props.ts:142](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L142)
 
----
+___
 
 #### onClose
 
@@ -415,9 +426,9 @@ Optional callback to be called when the chat is closed via the close button.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:141](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L141)
+[packages/chat-widget/src/props.ts:146](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L146)
 
----
+___
 
 #### onNudgeClose
 
@@ -431,8 +442,8 @@ Optional callback to be called when the nudge element is closed explicitly by th
 
 ###### Parameters
 
-| Name                  | Type                  |
-| :-------------------- | :-------------------- |
+| Name | Type |
+| :------ | :------ |
 | `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
@@ -441,27 +452,28 @@ Optional callback to be called when the nudge element is closed explicitly by th
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:145](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L145)
+[packages/chat-widget/src/props.ts:150](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L150)
 
----
+___
 
 #### customModalities
 
-• `Optional` **customModalities**: `Record`\<`string`, [`CustomModalityComponent`](#custommodalitycomponent)\>
+• `Optional` **customModalities**: `Record`\<`string`, [`CustomModalityComponent`](#custommodalitycomponent)\<`unknown`\>\>
 
 Set this to render a [CustomModalityComponent](#custommodalitycomponent) for a given modality name
 See: https://docs.studio.nlx.ai/build/resources/modalities
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:150](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L150)
+[packages/chat-widget/src/props.ts:155](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L155)
+
 
 <a name="interfacesthememd"></a>
 
 ## Interface: Theme
 
 The theme to apply to the chat widget.
-Colors may be in any CSS-compatible format like rgb(50, 50, 50) or #aaa
+ Colors may be in any CSS-compatible format like rgb(50, 50, 50) or #aaa
 
 ### Properties
 
@@ -473,9 +485,9 @@ Primary color for interactive UI elements like buttons
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:7](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L7)
+[packages/chat-widget/src/theme.ts:7](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L7)
 
----
+___
 
 #### darkMessageColor
 
@@ -485,9 +497,9 @@ Background color for the dark chat bubbles (sent by the user)
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:9](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L9)
+[packages/chat-widget/src/theme.ts:9](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L9)
 
----
+___
 
 #### lightMessageColor
 
@@ -497,9 +509,9 @@ Background color for the light chat bubbles (sent by the application)
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:11](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L11)
+[packages/chat-widget/src/theme.ts:11](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L11)
 
----
+___
 
 #### white
 
@@ -509,9 +521,9 @@ Customized shade of white
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:13](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L13)
+[packages/chat-widget/src/theme.ts:13](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L13)
 
----
+___
 
 #### fontFamily
 
@@ -521,9 +533,9 @@ Widget font family
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:15](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L15)
+[packages/chat-widget/src/theme.ts:15](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L15)
 
----
+___
 
 #### spacing
 
@@ -533,9 +545,9 @@ Main spacing unit
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:17](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L17)
+[packages/chat-widget/src/theme.ts:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L17)
 
----
+___
 
 #### borderRadius
 
@@ -545,9 +557,9 @@ Chat border radius
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:19](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L19)
+[packages/chat-widget/src/theme.ts:19](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L19)
 
----
+___
 
 #### chatWindowMaxHeight
 
@@ -557,7 +569,8 @@ Max height of the chat window
 
 ##### Defined in
 
-[packages/chat-widget/src/theme.ts:21](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/theme.ts#L21)
+[packages/chat-widget/src/theme.ts:21](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L21)
+
 
 <a name="interfacestitlebarmd"></a>
 
@@ -576,9 +589,9 @@ Optional URL to a logo image to be displayed on to the left of the title.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:13](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L13)
+[packages/chat-widget/src/props.ts:13](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L13)
 
----
+___
 
 #### title
 
@@ -588,22 +601,22 @@ The title string.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:17](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L17)
+[packages/chat-widget/src/props.ts:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L17)
 
----
+___
 
 #### withCollapseButton
 
 • `Optional` **withCollapseButton**: `boolean`
 
-Setting this to true shows the collapse button ("\_").
+Setting this to true shows the collapse button ("_").
 Pressing the collapse button will hide the chat overlay but keep it active.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:22](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L22)
+[packages/chat-widget/src/props.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L22)
 
----
+___
 
 #### withCloseButton
 
@@ -611,14 +624,14 @@ Pressing the collapse button will hide the chat overlay but keep it active.
 
 Setting this to true shows the close button ("X").
 Pressing the close button will
-
 - hide the chat overlay
 - terminate the ongoing conversation
 - call the chat's onClose handler if provided.
 
 ##### Defined in
 
-[packages/chat-widget/src/props.ts:30](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/props.ts#L30)
+[packages/chat-widget/src/props.ts:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L30)
+
 
 <a name="interfaceswidgetinstancemd"></a>
 
@@ -645,9 +658,9 @@ If you want to additionally clear a stored session, explicitly call [clearSessio
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:74](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L74)
+[packages/chat-widget/src/index.tsx:74](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L74)
 
----
+___
 
 #### expand
 
@@ -665,9 +678,9 @@ Expand the widget and call the `onExpand` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:78](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L78)
+[packages/chat-widget/src/index.tsx:78](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L78)
 
----
+___
 
 #### collapse
 
@@ -685,9 +698,9 @@ Collapse the widget and call the `onCollapse` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:82](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L82)
+[packages/chat-widget/src/index.tsx:82](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L82)
 
----
+___
 
 #### getConversationHandler
 
@@ -707,7 +720,8 @@ See: https://developers.nlx.ai/headless-api-reference#interfacesconversationhand
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:88](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L88)
+[packages/chat-widget/src/index.tsx:88](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L88)
+
 
 <a name="interfaceswidgetrefmd"></a>
 
@@ -733,9 +747,9 @@ Expand the widget and call the `onExpand` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:98](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L98)
+[packages/chat-widget/src/index.tsx:98](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L98)
 
----
+___
 
 #### collapse
 
@@ -753,9 +767,9 @@ Collapse the widget and call the `onCollapse` callback if present.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:102](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L102)
+[packages/chat-widget/src/index.tsx:102](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L102)
 
----
+___
 
 #### conversationHandler
 
@@ -765,4 +779,4 @@ the ConversationHandler for the widget.
 
 ##### Defined in
 
-[packages/chat-widget/src/index.tsx:106](https://github.com/nlxai/sdk/blob/4ed1b691443f6f0d50583f93b653454e560516a7/packages/chat-widget/src/index.tsx#L106)
+[packages/chat-widget/src/index.tsx:106](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L106)

--- a/packages/website/src/content/web-widget-api-reference.md
+++ b/packages/website/src/content/web-widget-api-reference.md
@@ -1,4 +1,3 @@
-
 <a name="readmemd"></a>
 
 # @nlxai/chat-widget
@@ -16,7 +15,7 @@
 
 ### StorageType
 
-Ƭ **StorageType**: ``"localStorage"`` \| ``"sessionStorage"``
+Ƭ **StorageType**: `"localStorage"` \| `"sessionStorage"`
 
 When this option is set to `"localStorage"` or `"sessionStorage"`,
 the state of the chat conversation is persisted in [local](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
@@ -33,20 +32,20 @@ full page refreshes.
 
 [packages/chat-widget/src/props.ts:45](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L45)
 
-___
+---
 
 ### CustomModalityComponent
 
-Ƭ **CustomModalityComponent**\<`T`\>: `ComponentType`\<\{ `key`: `string` ; `data`: `T` ; `conversationHandler`: `ConversationHandler`  }\>
+Ƭ **CustomModalityComponent**\<`T`\>: `ComponentType`\<\{ `key`: `string` ; `data`: `T` ; `conversationHandler`: `ConversationHandler` }\>
 
 Custom Modalities allow rendering of rich components from nodes.
 See: https://docs.studio.nlx.ai/build/resources/modalities
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `unknown` |
+| Name | Type      |
+| :--- | :-------- |
+| `T`  | `unknown` |
 
 #### Defined in
 
@@ -68,19 +67,19 @@ the default theme
 
 ### getCurrentExpirationTimestamp
 
-▸ **getCurrentExpirationTimestamp**(`responses`): ``null`` \| `number`
+▸ **getCurrentExpirationTimestamp**(`responses`): `null` \| `number`
 
 Get current expiration timestamp from the current list of reponses
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name        | Type         | Description                                                                           |
+| :---------- | :----------- | :------------------------------------------------------------------------------------ |
 | `responses` | `Response`[] | the current list of user and bot responses (first argument in the subscribe callback) |
 
 #### Returns
 
-``null`` \| `number`
+`null` \| `number`
 
 an expiration timestamp in Unix Epoch (`new Date().getTime()`), or `null` if this is not known (typically occurs if the bot has not responded yet)
 
@@ -88,7 +87,7 @@ an expiration timestamp in Unix Epoch (`new Date().getTime()`), or `null` if thi
 
 packages/chat-core/lib/index.d.ts:735
 
-___
+---
 
 ### create
 
@@ -98,8 +97,8 @@ Create a new chat widget and renders it as the last element in the body.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type                          |
+| :------ | :---------------------------- |
 | `props` | [`Props`](#interfacespropsmd) |
 
 #### Returns
@@ -112,7 +111,7 @@ the WidgetInstance to script widget behavior.
 
 [packages/chat-widget/src/index.tsx:114](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L114)
 
-___
+---
 
 ### clearSession
 
@@ -122,8 +121,8 @@ Clears stored session history.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type                          | Description                 |
+| :-------- | :---------------------------- | :-------------------------- |
 | `storeIn` | [`StorageType`](#storagetype) | where to clear the session. |
 
 #### Returns
@@ -134,11 +133,11 @@ Clears stored session history.
 
 [packages/chat-widget/src/index.tsx:357](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L357)
 
-___
+---
 
 ### useConversationHandler
 
-▸ **useConversationHandler**(): ``null`` \| `ConversationHandler`
+▸ **useConversationHandler**(): `null` \| `ConversationHandler`
 
 Hook to get the ConversationHandler for the widget.
 This may be called before the Widget has been created.
@@ -146,7 +145,7 @@ It will return null until the Widget has been created and the conversation has b
 
 #### Returns
 
-``null`` \| `ConversationHandler`
+`null` \| `ConversationHandler`
 
 the ConversationHandler if the widget has been created and its conversation has been established, otherwise it returns null.
 
@@ -154,7 +153,7 @@ the ConversationHandler if the widget has been created and its conversation has 
 
 [packages/chat-widget/src/index.tsx:480](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L480)
 
-___
+---
 
 ### Widget
 
@@ -162,8 +161,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type                                                                                     |
+| :------ | :--------------------------------------------------------------------------------------- |
 | `props` | [`Props`](#interfacespropsmd) & `RefAttributes`\<[`WidgetRef`](#interfaceswidgetrefmd)\> |
 
 #### Returns
@@ -174,12 +173,9 @@ ___
 
 [packages/chat-widget/src/index.tsx:484](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L484)
 
-
 <a name="indexmd"></a>
 
-
 # Interfaces
-
 
 <a name="interfacesnudgemd"></a>
 
@@ -203,7 +199,7 @@ The text content of the nudge. Markdown is supported.
 
 [packages/chat-widget/src/props.ts:78](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L78)
 
-___
+---
 
 #### showAfter
 
@@ -216,7 +212,7 @@ Defaults to 3000 (3s) if not set.
 
 [packages/chat-widget/src/props.ts:83](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L83)
 
-___
+---
 
 #### hideAfter
 
@@ -228,7 +224,6 @@ Defaults to 20000 (20s) if not set.
 ##### Defined in
 
 [packages/chat-widget/src/props.ts:88](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L88)
-
 
 <a name="interfacespropsmd"></a>
 
@@ -248,7 +243,7 @@ The configuration to create a conversation.
 
 [packages/chat-widget/src/props.ts:98](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L98)
 
-___
+---
 
 #### theme
 
@@ -260,7 +255,7 @@ The theme to apply to the chat widget.
 
 [packages/chat-widget/src/props.ts:102](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L102)
 
-___
+---
 
 #### titleBar
 
@@ -272,7 +267,7 @@ How to configure the title bar. When missing, the widget will not have a title b
 
 [packages/chat-widget/src/props.ts:106](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L106)
 
-___
+---
 
 #### chatIcon
 
@@ -284,7 +279,7 @@ If you want a custom chat icon, set this to the URL of an image to use.
 
 [packages/chat-widget/src/props.ts:110](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L110)
 
-___
+---
 
 #### nudge
 
@@ -296,7 +291,7 @@ An optional [Nudge](#interfacesnudgemd) configuration object.
 
 [packages/chat-widget/src/props.ts:114](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L114)
 
-___
+---
 
 #### inputPlaceholder
 
@@ -308,7 +303,7 @@ The placeholder in the input field. When not set, the default placeholder is "Ty
 
 [packages/chat-widget/src/props.ts:118](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L118)
 
-___
+---
 
 #### loaderMessage
 
@@ -320,7 +315,7 @@ A message to display to the user while the bot is still processing the previous 
 
 [packages/chat-widget/src/props.ts:122](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L122)
 
-___
+---
 
 #### showLoaderMessageAfter
 
@@ -332,7 +327,7 @@ How long to wait, in milliseconds, before the loader message is displayed. Defau
 
 [packages/chat-widget/src/props.ts:126](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L126)
 
-___
+---
 
 #### allowChoiceReselection
 
@@ -344,7 +339,7 @@ If set to true, previously selected choices in the chat can be changed.
 
 [packages/chat-widget/src/props.ts:130](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L130)
 
-___
+---
 
 #### storeIn
 
@@ -356,7 +351,7 @@ When set, chat history & conversation will be stored in the browser.
 
 [packages/chat-widget/src/props.ts:134](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L134)
 
-___
+---
 
 #### onExpand
 
@@ -370,8 +365,8 @@ Optional callback to be called when the chat is expanded.
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name                  | Type                  |
+| :-------------------- | :-------------------- |
 | `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
@@ -382,7 +377,7 @@ Optional callback to be called when the chat is expanded.
 
 [packages/chat-widget/src/props.ts:138](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L138)
 
-___
+---
 
 #### onCollapse
 
@@ -396,8 +391,8 @@ Optional callback to be called when the chat is collapsed. This is also called w
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name                  | Type                  |
+| :-------------------- | :-------------------- |
 | `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
@@ -408,7 +403,7 @@ Optional callback to be called when the chat is collapsed. This is also called w
 
 [packages/chat-widget/src/props.ts:142](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L142)
 
-___
+---
 
 #### onClose
 
@@ -428,7 +423,7 @@ Optional callback to be called when the chat is closed via the close button.
 
 [packages/chat-widget/src/props.ts:146](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L146)
 
-___
+---
 
 #### onNudgeClose
 
@@ -442,8 +437,8 @@ Optional callback to be called when the nudge element is closed explicitly by th
 
 ###### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name                  | Type                  |
+| :-------------------- | :-------------------- |
 | `conversationHandler` | `ConversationHandler` |
 
 ###### Returns
@@ -454,7 +449,7 @@ Optional callback to be called when the nudge element is closed explicitly by th
 
 [packages/chat-widget/src/props.ts:150](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L150)
 
-___
+---
 
 #### customModalities
 
@@ -467,13 +462,12 @@ See: https://docs.studio.nlx.ai/build/resources/modalities
 
 [packages/chat-widget/src/props.ts:155](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L155)
 
-
 <a name="interfacesthememd"></a>
 
 ## Interface: Theme
 
 The theme to apply to the chat widget.
- Colors may be in any CSS-compatible format like rgb(50, 50, 50) or #aaa
+Colors may be in any CSS-compatible format like rgb(50, 50, 50) or #aaa
 
 ### Properties
 
@@ -487,7 +481,7 @@ Primary color for interactive UI elements like buttons
 
 [packages/chat-widget/src/theme.ts:7](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L7)
 
-___
+---
 
 #### darkMessageColor
 
@@ -499,7 +493,7 @@ Background color for the dark chat bubbles (sent by the user)
 
 [packages/chat-widget/src/theme.ts:9](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L9)
 
-___
+---
 
 #### lightMessageColor
 
@@ -511,7 +505,7 @@ Background color for the light chat bubbles (sent by the application)
 
 [packages/chat-widget/src/theme.ts:11](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L11)
 
-___
+---
 
 #### white
 
@@ -523,7 +517,7 @@ Customized shade of white
 
 [packages/chat-widget/src/theme.ts:13](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L13)
 
-___
+---
 
 #### fontFamily
 
@@ -535,7 +529,7 @@ Widget font family
 
 [packages/chat-widget/src/theme.ts:15](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L15)
 
-___
+---
 
 #### spacing
 
@@ -547,7 +541,7 @@ Main spacing unit
 
 [packages/chat-widget/src/theme.ts:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L17)
 
-___
+---
 
 #### borderRadius
 
@@ -559,7 +553,7 @@ Chat border radius
 
 [packages/chat-widget/src/theme.ts:19](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L19)
 
-___
+---
 
 #### chatWindowMaxHeight
 
@@ -570,7 +564,6 @@ Max height of the chat window
 ##### Defined in
 
 [packages/chat-widget/src/theme.ts:21](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/theme.ts#L21)
-
 
 <a name="interfacestitlebarmd"></a>
 
@@ -591,7 +584,7 @@ Optional URL to a logo image to be displayed on to the left of the title.
 
 [packages/chat-widget/src/props.ts:13](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L13)
 
-___
+---
 
 #### title
 
@@ -603,20 +596,20 @@ The title string.
 
 [packages/chat-widget/src/props.ts:17](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L17)
 
-___
+---
 
 #### withCollapseButton
 
 • `Optional` **withCollapseButton**: `boolean`
 
-Setting this to true shows the collapse button ("_").
+Setting this to true shows the collapse button ("\_").
 Pressing the collapse button will hide the chat overlay but keep it active.
 
 ##### Defined in
 
 [packages/chat-widget/src/props.ts:22](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L22)
 
-___
+---
 
 #### withCloseButton
 
@@ -624,6 +617,7 @@ ___
 
 Setting this to true shows the close button ("X").
 Pressing the close button will
+
 - hide the chat overlay
 - terminate the ongoing conversation
 - call the chat's onClose handler if provided.
@@ -631,7 +625,6 @@ Pressing the close button will
 ##### Defined in
 
 [packages/chat-widget/src/props.ts:30](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/props.ts#L30)
-
 
 <a name="interfaceswidgetinstancemd"></a>
 
@@ -660,7 +653,7 @@ If you want to additionally clear a stored session, explicitly call [clearSessio
 
 [packages/chat-widget/src/index.tsx:74](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L74)
 
-___
+---
 
 #### expand
 
@@ -680,7 +673,7 @@ Expand the widget and call the `onExpand` callback if present.
 
 [packages/chat-widget/src/index.tsx:78](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L78)
 
-___
+---
 
 #### collapse
 
@@ -700,7 +693,7 @@ Collapse the widget and call the `onCollapse` callback if present.
 
 [packages/chat-widget/src/index.tsx:82](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L82)
 
-___
+---
 
 #### getConversationHandler
 
@@ -721,7 +714,6 @@ See: https://developers.nlx.ai/headless-api-reference#interfacesconversationhand
 ##### Defined in
 
 [packages/chat-widget/src/index.tsx:88](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L88)
-
 
 <a name="interfaceswidgetrefmd"></a>
 
@@ -749,7 +741,7 @@ Expand the widget and call the `onExpand` callback if present.
 
 [packages/chat-widget/src/index.tsx:98](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L98)
 
-___
+---
 
 #### collapse
 
@@ -769,7 +761,7 @@ Collapse the widget and call the `onCollapse` callback if present.
 
 [packages/chat-widget/src/index.tsx:102](https://github.com/nlxai/sdk/blob/0ffb6c1566a0c22d1f12b3a120556d8931f7df65/packages/chat-widget/src/index.tsx#L102)
 
-___
+---
 
 #### conversationHandler
 

--- a/packages/website/src/index.css
+++ b/packages/website/src/index.css
@@ -378,3 +378,7 @@ body {
 .linenumber {
   @apply text-primary-40;
 }
+
+.prose section > h3 {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
<img width="904" alt="Screenshot 2025-07-07 at 14 51 03" src="https://github.com/user-attachments/assets/d5af1df9-f24c-465e-8d47-c31a2d1acef3" />

There's certainly more that can be done here - I think there should be some improvements made with figuring out a more sensible order/structure to the docs.

But this seems to my eyes as much easier to browse, as it makes grouping and structure a lot easier to see (and also de-emphasizes the GitHub links).