### PR TITLE
Add reset button to voice mini

### DIFF
--- a/packages/touchpoint-ui/src/App.tsx
+++ b/packages/touchpoint-ui/src/App.tsx
@@ -219,6 +219,14 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
   // Used as key to voice components so they are destroyed and re-initialized e.g. on conversation reset
   const [voiceKey, setVoiceKey] = useState<number>(0);
 
+  const reset = (): void => {
+    handler.reset({ clearResponses: true });
+    if (input !== "voice") {
+      props.initializeConversation(handler, props.initialContext);
+    }
+    setVoiceKey((prev) => prev + 1);
+  };
+
   if (handler == null) {
     return null;
   }
@@ -268,6 +276,7 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
           }}
           renderCollapse={props.onClose != null}
           customModalities={customModalities}
+          reset={reset}
         />
       </CustomPropertiesContainer>
     );
@@ -341,14 +350,6 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
         </div>
       </>
     );
-  };
-
-  const reset = (): void => {
-    handler.reset({ clearResponses: true });
-    if (input !== "voice") {
-      props.initializeConversation(handler, props.initialContext);
-    }
-    setVoiceKey((prev) => prev + 1);
   };
 
   return (

--- a/packages/touchpoint-ui/src/components/VoiceMini.tsx
+++ b/packages/touchpoint-ui/src/components/VoiceMini.tsx
@@ -8,7 +8,15 @@ import { useVoice } from "../voice";
 import { LoaderAnimation } from "./ui/Loader";
 import { Ripple } from "./Ripple";
 import { IconButton } from "./ui/IconButton";
-import { Close, Mic, MicOff, Volume, VolumeOff, Restart } from "./ui/Icons";
+import {
+  Close,
+  Mic,
+  MicOff,
+  Volume,
+  VolumeOff,
+  Restart,
+  Undo,
+} from "./ui/Icons";
 import { TextButton } from "./ui/TextButton";
 import { VoiceModalities } from "./FullscreenVoice";
 import { ErrorMessage } from "./ErrorMessage";
@@ -57,12 +65,20 @@ const VoiceModalitiesWrapper: FC<{ children: ReactNode }> = ({ children }) => (
 );
 
 export const VoiceMini: FC<{
+  reset: () => void;
   customModalities: Record<string, CustomModalityComponent<unknown>>;
   handler: ConversationHandler;
   renderCollapse: boolean;
   onClose: (event: Event) => void;
   context?: Context;
-}> = ({ handler, context, onClose, customModalities, renderCollapse }) => {
+}> = ({
+  handler,
+  context,
+  onClose,
+  customModalities,
+  renderCollapse,
+  reset,
+}) => {
   const [micEnabled, setMicEnabled] = useState<boolean>(true);
   const [speakersEnabled, setSpeakersEnabled] = useState<boolean>(true);
 
@@ -146,6 +162,7 @@ export const VoiceMini: FC<{
           }}
         />
       </div>
+      <IconButton label="Reset" type="ghost" onClick={reset} Icon={Undo} />
       <IconButton
         label="Close"
         Icon={Close}


### PR DESCRIPTION
Closing and re-opening voice mini no longer resets the conversation, so an explicit reset button is necessary.

See https://nlxai.slack.com/archives/C01RGUJ519V/p1752769152682209.