### PR TITLE
Fixes various misconfiguration

### DIFF
--- a/packages/touchpoint-ui/src/App.tsx
+++ b/packages/touchpoint-ui/src/App.tsx
@@ -154,6 +154,7 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
 
   useEffect(() => {
     if (
+      isExpanded &&
       props.bidirectional != null &&
       props.bidirectional.automaticContext !== false
     ) {
@@ -161,7 +162,7 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
         pageState.current = val;
       });
     }
-  }, [handler, props.bidirectional]);
+  }, [isExpanded, handler, props.bidirectional]);
 
   useEffect(() => {
     if (

--- a/packages/touchpoint-ui/src/bidirectional/automaticContext.ts
+++ b/packages/touchpoint-ui/src/bidirectional/automaticContext.ts
@@ -4,6 +4,7 @@ import { computeAccessibleName } from "dom-accessibility-api";
 import type { ConversationHandler } from "@nlxai/chat-core";
 import { analyzePageForms } from "./analyzePageForms";
 import { equals, uniq } from "ramda";
+import { debug } from "./debug";
 
 const debounceAsync = <T extends any[]>(
   func: (...args: T) => Promise<void>,
@@ -63,11 +64,7 @@ export const gatherAutomaticContext = (
       const [context, pageState] = gatherContext();
       if (!equals(previousContext, context)) {
         try {
-          // eslint-disable-next-line no-console
-          console.debug(
-            "Bidirectional automatic context sent:",
-            context["nlx:vpContext"],
-          );
+          debug("Automatic context sent:", context["nlx:vpContext"]);
           await handler.sendContext(context);
         } catch (error) {}
         setPageState(pageState);

--- a/packages/touchpoint-ui/src/bidirectional/debug.ts
+++ b/packages/touchpoint-ui/src/bidirectional/debug.ts
@@ -1,0 +1,5 @@
+/* eslint-disable jsdoc/require-jsdoc */
+export const debug = (message: string, ...args: unknown[]): void => {
+  // eslint-disable-next-line no-console
+  console.debug(`[NLX V+] ${message}`, ...args);
+};

--- a/packages/touchpoint-ui/src/index.tsx
+++ b/packages/touchpoint-ui/src/index.tsx
@@ -134,7 +134,10 @@ const normalizeConfiguration = (
         configuration.config.userId ??
         localStorage.getItem("nlxUserId") ??
         defaultUserId(),
-      bidirectional: configuration.config.bidirectional ?? false,
+      bidirectional:
+        configuration.bidirectional == null
+          ? configuration.config.bidirectional ?? false
+          : true,
     },
     input: configuration.input ?? "text",
     initializeConversation:

--- a/packages/touchpoint-ui/src/types.ts
+++ b/packages/touchpoint-ui/src/types.ts
@@ -218,7 +218,7 @@ export type BidirectionalConfig =
        * @param destinations - A map of destination names to URLs for custom navigation. Only present if `automaticContext` is enabled.
        */
       navigation?: (
-        action: "page_next" | "page_previous" | "page_custom",
+        action: "page_next" | "page_previous" | "page_custom" | "page_unknown",
         destination: string | undefined,
         destinations: Record<string, string>,
       ) => void;
@@ -260,7 +260,7 @@ export type BidirectionalConfig =
        * @param destination - The name of the destination to navigate to if `action` is `"page_custom"`.
        */
       navigation?: (
-        action: "page_next" | "page_previous" | "page_custom",
+        action: "page_next" | "page_previous" | "page_custom" | "page_unknown",
         destination?: string,
       ) => void;
       /**

--- a/packages/touchpoint-ui/src/voice.ts
+++ b/packages/touchpoint-ui/src/voice.ts
@@ -11,6 +11,7 @@ import {
   ParticipantEvent,
   Room,
   RoomEvent,
+  setLogLevel,
   Track,
   type Participant,
   type RemoteTrack,
@@ -27,6 +28,11 @@ export interface ModalitiesWithContext {
   modalities: ModalityPayloads;
   from?: string;
   timestamp: number;
+}
+if (process.env.NODE_ENV === "development") {
+  setLogLevel("info");
+} else {
+  setLogLevel("error");
 }
 
 const decodeModalities = (val: Uint8Array): ModalityPayloads | null => {


### PR DESCRIPTION
The problem was on [this line](#diff-9f8226a4f6e54253f828f937acc5bf80d1e01c6a12c826bcc4708102b1078e5fR137), 
but the PR includes various other improvements, like a nice little tag for filtering logs which should make it easier to debug V+ interactions. Also fixes an issue with context being sent before the widget is opened.