### PR TITLE
Add way to define available custom actions and send them in

### DIFF
--- a/packages/touchpoint-ui/index.html
+++ b/packages/touchpoint-ui/index.html
@@ -143,10 +143,26 @@
           userId: "1234-5678",
           languageCode: "en-US",
         },
-        input: "voice",
+        input: "voiceMini",
         launchIcon: CustomLaunchButton,
-        initializeConversation: () => {},
+        bidirectional: {
+          customizeAutomaticContext(arg) {
+            console.log("Customizing automatic context with arg:", arg);
+            arg.context.uri = "foo";
+            return arg;
+          },
+        },
       });
+
+      touchpoint.setCustomBidirectionalCommands([
+        {
+          name: "Eat a burger",
+          description: "Eat a delicious hamburger",
+          handler: () => {
+            console.log("Custom command executed with args:", args);
+          },
+        },
+      ]);
     </script>
   </body>
 </html>

--- a/packages/touchpoint-ui/index.html
+++ b/packages/touchpoint-ui/index.html
@@ -134,18 +134,22 @@
       };
 
       const touchpoint = await create({
+        // https://dev.platform.nlx.ai/applications/fe041de0-bc87-4120-a6db-443ab1107ad3 in the dev workspace
         config: {
           applicationUrl:
-            "https://bots.dev.studio.nlx.ai/c/CBuQ3LpsClG5EQoSObVkK/IPzJitiaN8qtJFL3Wz1Jp",
+            "https://bots.dev.studio.nlx.ai/c/XeHWunu1RQOVcVzKIQoo5/cKdh8IsqmA0syks0R9oBh",
           headers: {
-            "nlx-api-key": "m3kVBd9QeCc5bXInhWIPG3ns",
+            "nlx-api-key": "8afGyqKJoObPj4g-UFNUc65s",
           },
-          userId: "1234-5678",
+          userId: "sdk-test-user",
           languageCode: "en-US",
         },
         input: "voiceMini",
         launchIcon: CustomLaunchButton,
         bidirectional: {
+          custom(action, payload) {
+            console.log("Custom bidirectional action:", action, payload);
+          },
           customizeAutomaticContext(arg) {
             console.log("Customizing automatic context with arg:", arg);
             arg.context.uri = "foo";
@@ -156,8 +160,8 @@
 
       touchpoint.setCustomBidirectionalCommands([
         {
-          name: "Eat a burger",
-          description: "Eat a delicious hamburger",
+          name: "burger",
+          description: "Eat a hamburger",
           handler: () => {
             console.log("Custom command executed with args:", args);
           },

--- a/packages/touchpoint-ui/src/App.tsx
+++ b/packages/touchpoint-ui/src/App.tsx
@@ -32,11 +32,11 @@ import type {
   WindowSize,
   ChoiceMessage,
   BidirectionalCustomCommand,
+  PageState,
 } from "./interface";
 import type {
   NormalizedTouchpointConfiguration,
   DowncastCustomCommand,
-  PageState,
 } from "./types";
 import { CustomPropertiesContainer } from "./components/Theme";
 import { VoiceMini } from "./components/VoiceMini";
@@ -185,9 +185,19 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
     customCommands: new Map(),
   });
 
+  const initialCustomCommands = useRef<DowncastCustomCommand[]>([]);
+
   const customCommandsChangeHandler = useRef<
     (commands: DowncastCustomCommand[]) => void
-  >(() => {});
+  >((cmds) => {
+    if (props.bidirectional?.automaticContext !== false) {
+      initialCustomCommands.current = cmds;
+    } else {
+      throw new Error(
+        "Custom commands can only be set when automatic context is enabled.",
+      );
+    }
+  });
 
   useEffect(() => {
     if (
@@ -197,6 +207,8 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
     ) {
       const { teardown, onCustomCommandsChange } = gatherAutomaticContext(
         handler,
+        initialCustomCommands.current,
+        props.bidirectional.customizeAutomaticContext ?? ((arg) => arg),
         (val) => {
           pageState.current = val;
         },

--- a/packages/touchpoint-ui/src/bidirectional/automaticContext.ts
+++ b/packages/touchpoint-ui/src/bidirectional/automaticContext.ts
@@ -5,6 +5,11 @@ import type { ConversationHandler } from "@nlxai/core";
 import { analyzePageForms } from "./analyzePageForms";
 import { equals, uniq } from "ramda";
 import { debug } from "./debug";
+import type {
+  BidirectionalContext,
+  DowncastCustomCommand,
+  PageState,
+} from "../types";
 
 const debounceAsync = <T extends any[]>(
   func: (...args: T) => Promise<void>,
@@ -40,32 +45,27 @@ const debounceAsync = <T extends any[]>(
 
 export const gatherAutomaticContext = (
   handler: ConversationHandler,
-  setPageState: (state: {
-    formElements: any;
-    links: Record<string, string>;
-  }) => void,
-): (() => void) => {
-  let previousContext: {
-    "nlx:vpContext": {
-      // url: string;
-      fields: any;
-      destinations: any;
-    };
-  } = {
-    "nlx:vpContext": {
-      // url: "",
-      fields: {},
-      destinations: {},
-    },
+  setPageState: (state: PageState) => void,
+): {
+  teardown: () => void;
+  onCustomCommandsChange: (commands: DowncastCustomCommand[]) => void;
+} => {
+  let previousContext: BidirectionalContext = {
+    uri: "",
+    fields: [],
+    destinations: [],
+    actions: [],
   };
+
+  let customCommands: DowncastCustomCommand[] = [];
 
   const go = debounceAsync(
     async () => {
-      const [context, pageState] = gatherContext();
+      const [context, pageState] = gatherContext(customCommands);
       if (!equals(previousContext, context)) {
         try {
-          debug("Automatic context sent:", context["nlx:vpContext"]);
-          await handler.sendContext(context);
+          debug("Automatic context sent:", context);
+          await handler.sendContext({ "nlx:vpContext": context });
         } catch (error) {}
         setPageState(pageState);
         previousContext = context;
@@ -85,35 +85,45 @@ export const gatherAutomaticContext = (
   });
 
   // Return a cleanup function to disconnect the observer
-  return () => {
-    observer.disconnect();
+  return {
+    teardown: () => {
+      observer.disconnect();
+    },
+    onCustomCommandsChange: (commands) => {
+      customCommands = commands;
+      go();
+    },
   };
 };
 
-const gatherContext = (): [
-  {
-    "nlx:vpContext": {
-      // url: string;
-      fields: any;
-      destinations: any;
-    };
-  },
-  { formElements: any; links: Record<string, string> },
-] => {
+const gatherContext = (
+  customCommands: DowncastCustomCommand[],
+): [BidirectionalContext, PageState] => {
   const { context: fields, formElements } = analyzePageForms();
   const { context: destinations, links } = analyzePageLinks();
 
   const context = {
-    // url: window.location.href,
+    uri: window.location.href,
     fields,
     destinations,
+    actions: customCommands.map((command) => {
+      const { handler: _, ...commandWithoutHandler } = command;
+      return commandWithoutHandler;
+    }),
   };
 
   return [
+    context,
     {
-      "nlx:vpContext": context,
+      formElements,
+      links,
+      customCommands: new Map(
+        customCommands.map((c) => [
+          c.name,
+          { handler: c.handler, values: c.values ?? [] },
+        ]),
+      ),
     },
-    { formElements, links },
   ];
 };
 

--- a/packages/touchpoint-ui/src/bidirectional/commandHandler.ts
+++ b/packages/touchpoint-ui/src/bidirectional/commandHandler.ts
@@ -102,7 +102,6 @@ export const commandHandler = (
                 )))
           ) {
             handler(event.payload);
-            break;
           } else {
             debug(
               `Custom command "${event.action}" received, but the payload ${event.payload} does not match the expected values.`,

--- a/packages/touchpoint-ui/src/bidirectional/commandHandler.ts
+++ b/packages/touchpoint-ui/src/bidirectional/commandHandler.ts
@@ -1,8 +1,7 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import type { ConversationHandler } from "@nlxai/core";
-import type { BidirectionalConfig } from "../interface";
+import type { PageState, BidirectionalConfig } from "../interface";
 import { debug } from "./debug";
-import type { PageState } from "../types";
 import { equals } from "ramda";
 
 export const commandHandler = (

--- a/packages/touchpoint-ui/src/components/FullscreenVoice.tsx
+++ b/packages/touchpoint-ui/src/components/FullscreenVoice.tsx
@@ -6,7 +6,7 @@ import type {
   ColorMode,
   InitializeConversation,
   CustomModalityComponent,
-} from "../types";
+} from "../interface";
 
 import { FullscreenError } from "./FullscreenError";
 import { Ripple } from "./Ripple";

--- a/packages/touchpoint-ui/src/components/Header.tsx
+++ b/packages/touchpoint-ui/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { type SetStateAction, type Dispatch, type FC } from "react";
 import { clsx } from "clsx";
 
 import { IconButton, type IconButtonType } from "./ui/IconButton";
-import { type WindowSize, type ColorMode } from "../types";
+import { type WindowSize, type ColorMode } from "../interface";
 import { useTailwindMediaQuery } from "../hooks";
 import { Close, Settings, Undo, Volume, VolumeOff } from "./ui/Icons";
 

--- a/packages/touchpoint-ui/src/components/Messages.tsx
+++ b/packages/touchpoint-ui/src/components/Messages.tsx
@@ -15,7 +15,7 @@ import { LoaderAnimation, Loader } from "./ui/Loader";
 import { TextButton } from "./ui/TextButton";
 import { ArrowForward, ArrowRight, ArrowDown, OpenLink } from "./ui/Icons";
 import { UnsemanticIconButton } from "./ui/IconButton";
-import { type CustomModalityComponent, type ColorMode } from "../types";
+import { type CustomModalityComponent, type ColorMode } from "../interface";
 
 export interface MessagesProps {
   isWaiting: boolean;

--- a/packages/touchpoint-ui/src/components/Theme.tsx
+++ b/packages/touchpoint-ui/src/components/Theme.tsx
@@ -2,7 +2,7 @@
 import { type FC, type ReactNode, type CSSProperties } from "react";
 import { clsx } from "clsx";
 
-import { type ColorMode, type Theme } from "../types";
+import { type ColorMode, type Theme } from "../interface";
 
 const toCustomProperties = (theme: Theme): CSSProperties => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/touchpoint-ui/src/components/VoiceMini.tsx
+++ b/packages/touchpoint-ui/src/components/VoiceMini.tsx
@@ -3,7 +3,7 @@ import type { Context, ConversationHandler } from "@nlxai/core";
 import { type ReactNode, useState, type FC } from "react";
 import { clsx } from "clsx";
 
-import type { CustomModalityComponent } from "../types";
+import type { CustomModalityComponent } from "../interface";
 import { useVoice } from "../voice";
 import { LoaderAnimation } from "./ui/Loader";
 import { Ripple } from "./Ripple";

--- a/packages/touchpoint-ui/src/components/defaultModalities/DefaultCard.tsx
+++ b/packages/touchpoint-ui/src/components/defaultModalities/DefaultCard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable jsdoc/require-jsdoc */
-import { type CustomModalityComponent } from "../../types";
+import { type CustomModalityComponent } from "../../interface";
 import {
   CustomCard,
   CustomCardImageRow,

--- a/packages/touchpoint-ui/src/components/defaultModalities/DefaultCarousel.tsx
+++ b/packages/touchpoint-ui/src/components/defaultModalities/DefaultCarousel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable jsdoc/require-jsdoc */
 import { useState, useMemo } from "react";
-import { type CustomModalityComponent } from "../../types";
+import { type CustomModalityComponent } from "../../interface";
 import { Carousel } from "../ui/Carousel";
 import {
   CustomCard,

--- a/packages/touchpoint-ui/src/components/defaultModalities/DefaultDateInput.tsx
+++ b/packages/touchpoint-ui/src/components/defaultModalities/DefaultDateInput.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 
 import { type SaveAs, saveFn } from "./shared";
-import { type CustomModalityComponent } from "../../types";
+import { type CustomModalityComponent } from "../../interface";
 import { DateInput } from "../ui/DateInput";
 
 export const DefaultDateInput: CustomModalityComponent<{

--- a/packages/touchpoint-ui/src/design-system.tsx
+++ b/packages/touchpoint-ui/src/design-system.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { clsx } from "clsx";
 
 import "./index.css";
-import { type ColorMode } from "./types";
+import { type ColorMode } from "./interface";
 import { TextButton } from "./components/ui/TextButton";
 import { IconButton } from "./components/ui/IconButton";
 import { Loader } from "./components/ui/Loader";

--- a/packages/touchpoint-ui/src/index.tsx
+++ b/packages/touchpoint-ui/src/index.tsx
@@ -100,7 +100,22 @@ export {
   type IconButtonType,
 } from "./components/ui/IconButton";
 export { type TextButtonProps } from "./components/ui/TextButton";
-export type * from "./interface";
+export type {
+  WindowSize,
+  ColorMode,
+  ChoiceMessage,
+  CustomModalityComponent,
+  Theme,
+  InitializeConversation,
+  CustomLaunchButton,
+  Input,
+  PageState,
+  BidirectionalContext,
+  BidirectionalConfig,
+  TouchpointConfiguration,
+  BidirectionalCustomCommand,
+  BidirectionalCustomCommands,
+} from "./interface";
 
 const defaultConversationId = (): string => {
   const id = crypto.randomUUID();

--- a/packages/touchpoint-ui/src/index.tsx
+++ b/packages/touchpoint-ui/src/index.tsx
@@ -26,10 +26,11 @@ import { DefaultCard } from "./components/defaultModalities/DefaultCard";
 import { DefaultCarousel } from "./components/defaultModalities/DefaultCarousel";
 
 import type {
-  NormalizedTouchpointConfiguration,
   TouchpointConfiguration,
   CustomModalityComponent,
-} from "./types";
+  BidirectionalCustomCommand,
+} from "./interface";
+import type { NormalizedTouchpointConfiguration } from "./types";
 export {
   analyzePageForms,
   type InteractiveElementInfo,
@@ -99,17 +100,7 @@ export {
   type IconButtonType,
 } from "./components/ui/IconButton";
 export { type TextButtonProps } from "./components/ui/TextButton";
-export {
-  type InitializeConversation,
-  type ColorMode,
-  type Input,
-  type Theme,
-  type WindowSize,
-  type CustomModalityComponent,
-  type TouchpointConfiguration,
-  type CustomLaunchButton,
-  type BidirectionalConfig,
-} from "./types";
+export type * from "./interface";
 
 const defaultConversationId = (): string => {
   const id = crypto.randomUUID();
@@ -338,6 +329,32 @@ export interface TouchpointInstance {
    * Method to remove the Touchpoint UI from the DOM
    */
   teardown: () => void;
+
+  /**
+   * Sets currently available custom bidirectional commands.
+   * This allows you to define custom commands that can be used in the voice bot.
+   * The commands will be available in the voice bot and can be used to trigger actions.
+   *
+   * Example:
+   * ```javascript
+   * client.setCustomBidirectionalCommands([
+   *     {
+   *       name: "Meal",
+   *       description: "add a meal to your flight",
+   *       values: ["standard", "vegetarian", "vegan", "gluten-free"],
+   *       multipleValues: false,
+   *       handler: (value) => {
+   *         console.log("Meal option:", value);
+   *       },
+   *     },
+   *   ]);
+   * ```
+   * This will allow the voice bot to use the command `myCommand` with the values `value1` and `value2`.
+   * @param commands - A list containing the custom commands to set.
+   */
+  setCustomBidirectionalCommands: <T extends unknown[]>(commands: {
+    [I in keyof T]: BidirectionalCustomCommand<T[I]>;
+  }) => void;
 }
 
 /**
@@ -365,6 +382,9 @@ export const create = (
         },
         teardown: () => {
           document.body.removeChild(element);
+        },
+        setCustomBidirectionalCommands(commands) {
+          ref.setCustomBidirectionalCommands(commands);
         },
       });
     };

--- a/packages/touchpoint-ui/src/interface.ts
+++ b/packages/touchpoint-ui/src/interface.ts
@@ -210,7 +210,15 @@ export interface PageState {
   /** Mapping from link element names to their URLs */
   links: Record<string, string>;
   /** Mapping from custom commans to their handlers (and values used to validate LLM output) */
-  customCommands: Map<string, { values: any[]; handler: (arg: any) => void }>;
+  customCommands: Map<
+    string,
+    {
+      /** Available values, used for validation. */
+      values: any[];
+      /** Handler that will be called when the command is invoked */
+      handler: (arg: any) => void;
+    }
+  >;
 }
 
 /**
@@ -223,13 +231,10 @@ export interface BidirectionalContext {
   fields?: InteractiveElementInfo[];
   /** Human readable location names that can be navigated to. */
   destinations?: string[];
-  /** Custom actions that can be performed. */
-  actions?: Array<{
-    name: string;
-    description?: string;
-    values?: any[];
-    multipleValues?: boolean;
-  }>;
+  /**
+   * Custom actions that can be performed.
+   */
+  actions?: Array<Omit<BidirectionalCustomCommand<any>, "handler">>;
 }
 
 /**
@@ -290,7 +295,16 @@ export type BidirectionalConfig =
       customizeAutomaticContext?: (arg: {
         context: BidirectionalContext;
         state: PageState;
-      }) => { context: BidirectionalContext; state: PageState };
+      }) => {
+        /**
+         * The current context being sent to the LLM
+         */
+        context: BidirectionalContext;
+        /**
+         * The current state of the page - this is stuff not sent to the LLM, but needed to connect the results back to actions to take on the page.
+         */
+        state: PageState;
+      };
     }
   | {
       /**

--- a/packages/touchpoint-ui/src/interface.ts
+++ b/packages/touchpoint-ui/src/interface.ts
@@ -1,0 +1,413 @@
+import type {
+  Config,
+  ApplicationMessage,
+  ConversationHandler,
+  Context,
+} from "@nlxai/core";
+import { type ComponentType } from "react";
+
+/**
+ * Window size configuration
+ */
+export type WindowSize = "half" | "full";
+
+/**
+ * Color mode configuration (light/dark modes)
+ */
+export type ColorMode = "light" | "dark";
+
+/**
+ * Choice message with metadata
+ */
+export interface ChoiceMessage {
+  /**
+   * Message contents
+   */
+  message: ApplicationMessage;
+  /**
+   * Index in the response transcript history
+   */
+  responseIndex: number;
+  /**
+   * Message index in the current response
+   */
+  messageIndex: number;
+}
+
+/**
+ * Custom Modalities allow rendering of rich components from nodes.
+ * See: https://docs.studio.nlx.ai/build/resources/modalities
+ */
+export type CustomModalityComponent<Data> = ComponentType<{
+  /**
+   * The payload of the Custom Modality. The schema is defined in Dialog Studio settings.
+   */
+  data: Data;
+  /**
+   * Conversation handler instance
+   */
+  conversationHandler: ConversationHandler;
+
+  /**
+   * Whether the component is enabled
+   * We should probably use context and handle disabling interactive components automatically for the user
+   * @internal
+   */
+  enabled: boolean;
+  /**
+   * Class name to propagate to the container
+   */
+  className?: string;
+}>;
+
+/**
+ * The full theme expressed as CSS custom properties
+ */
+export interface Theme {
+  /**
+   * Font family
+   */
+  fontFamily: string;
+
+  /**
+   * Primary color with 80% opacity
+   */
+  primary80: string;
+  /**
+   * Primary color with 60% opacity
+   */
+  primary60: string;
+  /**
+   * Primary color with 40% opacity
+   */
+  primary40: string;
+  /**
+   * Primary color with 20% opacity
+   */
+  primary20: string;
+  /**
+   * Primary color with 10% opacity
+   */
+  primary10: string;
+  /**
+   * Primary color with 5% opacity
+   */
+  primary5: string;
+  /**
+   * Primary color with 1% opacity
+   */
+  primary1: string;
+
+  /**
+   * Secondary color with 80% opacity
+   */
+  secondary80: string;
+  /**
+   * Secondary color with 60% opacity
+   */
+  secondary60: string;
+  /**
+   * Secondary color with 40% opacity
+   */
+  secondary40: string;
+  /**
+   * Secondary color with 20% opacity
+   */
+  secondary20: string;
+  /**
+   * Secondary color with 10% opacity
+   */
+  secondary10: string;
+  /**
+   * Secondary color with 5% opacity
+   */
+  secondary5: string;
+  /**
+   * Secondary color with 1% opacity
+   */
+  secondary1: string;
+
+  /**
+   * Accent color used e.g. for prominent buttons, the loader animation as well as selected card outlines
+   */
+  accent: string;
+  /**
+   * Accent color with 20% opacity
+   */
+  accent20: string;
+  /**
+   * The background color of the main Touchpoint interface
+   */
+  background: string;
+  /**
+   * The color of the overlay covering the visible portion of the website when the Touchpoint interface does not cover the full screen
+   */
+  overlay: string;
+
+  /**
+   * Primary warning color
+   */
+  warningPrimary: string;
+  /**
+   * Secondary warning color
+   */
+  warningSecondary: string;
+  /**
+   * Primary error color
+   */
+  errorPrimary: string;
+  /**
+   * Secondary error color
+   */
+  errorSecondary: string;
+
+  /**
+   * Inner border radius: used for most buttons
+   */
+  innerBorderRadius: string;
+  /**
+   * Outer border radius: generally used for elements that contain buttons that have inner border radius. Also used by the launch button.
+   */
+  outerBorderRadius: string;
+}
+
+/**
+ * Custom conversation init method. Defaults to sending the welcome intent
+ * @param handler - the conversation handler.
+ * @param context - context set via TouchpointConfiguration.initialContext
+ */
+export type InitializeConversation = (
+  handler: ConversationHandler,
+  context?: Context,
+) => void;
+
+/**
+ * Fully custom launch icon
+ */
+export type CustomLaunchButton = ComponentType<{
+  /**
+   * Class name injected into the component mainly to take care of positioning and z-index. Can be combined with more presentational and sizing-related class names.
+   */
+  className?: string;
+  /**
+   * Click handler that expands Touchpoint, without the caller having to implement this based on Touchpoint instance methods.
+   */
+  onClick?: () => void;
+}>;
+
+/**
+ * Input type for the experience
+ */
+export type Input = "text" | "voice" | "voiceMini";
+
+/**
+ * Configuration for bidirectional mode of voice+.
+ */
+export type BidirectionalConfig =
+  | {
+      /**
+       * Attempt to gather and send page context automatically. This will work well on semantically coded pages without too many custom form controls.
+       * This enables a number of automatic features.
+       *
+       * Defaults to `true`.
+       */
+      automaticContext?: true;
+
+      /**
+       * Navigation handler for bidirectional mode.
+       *
+       * If automatic context gathering is enabled, the default implementation will navigate to those pages using standard `window.location` APIs.
+       * @param action - The navigation action to perform.
+       * @param destination - The name of the destination to navigate to if `action` is `"page_custom"`.
+       * @param destinations - A map of destination names to URLs for custom navigation. Only present if `automaticContext` is enabled.
+       */
+      navigation?: (
+        action: "page_next" | "page_previous" | "page_custom" | "page_unknown",
+        destination: string | undefined,
+        destinations: Record<string, string>,
+      ) => void;
+
+      /**
+       * A callback for filling out form fields in bidirectional mode.
+       *
+       * If automatic context gathering is enabled, the default implementation will fill out the form fields using standard DOM APIs.
+       * @param fields - An array of field objects with `id` and `value` properties.
+       * @param pageFields - A map of field IDs to DOM elements for custom form filling. Only present if `automaticContext` is enabled.
+       */
+      input?: (
+        fields: Array<{ id: string; value: string }>,
+        pageFields: Record<string, Element>,
+      ) => void;
+
+      /**
+       * A callback for custom actions in bidirectional mode.
+       * @param action - The custom name of your action.
+       * @param payload - The payload defined for the custom action.
+       * @returns
+       */
+      custom?: (action: string, payload: unknown) => void;
+    }
+  | {
+      /**
+       * Attempt to gather and send page context automatically. This will work well on semantically coded pages without too many custom form controls.
+       * This enables a number of automatic features.
+       *
+       * Defaults to `true`.
+       */
+      automaticContext: false;
+
+      /**
+       * Navigation handler for bidirectional mode.
+       *
+       * If automatic context gathering is enabled, the default implementation will navigate to those pages using standard `window.location` APIs.
+       * @param action - The navigation action to perform.
+       * @param destination - The name of the destination to navigate to if `action` is `"page_custom"`.
+       */
+      navigation?: (
+        action: "page_next" | "page_previous" | "page_custom" | "page_unknown",
+        destination?: string,
+      ) => void;
+      /**
+       * A callback for filling out form fields in bidirectional mode.
+       *
+       * If automatic context gathering is enabled, the default implementation will fill out the form fields using standard DOM APIs.
+       * @param fields - An array of field objects with `id` and `value` properties.
+       */
+      input?: (fields: Array<{ id: string; value: string }>) => void;
+      /**
+       * A callback for custom actions in bidirectional mode.
+       * @param action - The custom name of your action.
+       * @param payload - The payload defined for the custom action.
+       * @returns
+       */
+      custom?: (action: string, payload: unknown) => void;
+    };
+
+/**
+ * Main Touchpoint creation properties object
+ */
+export interface TouchpointConfiguration {
+  /**
+   * Connection information for the \@nlxai/core conversation handler
+   */
+  config: Config;
+  /**
+   * Optional window size for the chat window, defaults to `half`
+   */
+  windowSize?: WindowSize;
+  /**
+   * Optional color mode for the chat window, defaults to `dark`
+   */
+  colorMode?: ColorMode;
+  /**
+   * URL of icon used to display the brand in the chat header
+   */
+  brandIcon?: string;
+  /**
+   * URL of icon used on the launch icon in the bottom right when the experience is collapsed.
+   *
+   * When set to `false`, no launch button is shown at all. When not set or set to `true`, the default launch icon is rendered.
+   */
+  launchIcon?: string | boolean | CustomLaunchButton;
+  /**
+   * Specifies whether the user message has bubbles or not
+   */
+  userMessageBubble?: boolean;
+  /**
+   * Specifies whether the agent message has bubbles or not
+   */
+  agentMessageBubble?: boolean;
+  /**
+   * Enables chat mode, a classic chat experience with inline loaders and the chat history visible at all times.
+   */
+  chatMode?: boolean;
+  /**
+   * Optional theme object to override default theme values
+   */
+  theme?: Partial<Theme>;
+  /**
+   * Optional custom modality components to render in Touchpoint
+   */
+  customModalities?: Record<string, CustomModalityComponent<unknown>>;
+  /**
+   * Custom conversation init method. Defaults to sending the welcome intent
+   * @param handler - the conversation handler.
+   * @param context - the context object
+   */
+  initializeConversation?: InitializeConversation;
+  /**
+   * Controls the ways in which  the user can communicate with the application. Defaults to `"text"`
+   */
+  input?: Input;
+  /**
+   * Context sent with the initial request.
+   */
+  initialContext?: Context;
+
+  /**
+   * Enables bidirectional mode of voice+. Will automatically set the bidirectional flag in the config.
+   *
+   */
+  bidirectional?: BidirectionalConfig;
+}
+
+/**
+ * During a Voice+ bidirectional conversation, you can indicate to the application the availability of
+ * custom commands that the user can invoke.
+ * @typeParam T - Commands can take a single parameter which will be selected from the list of values.
+ * These must be serializable to JSON.
+ */
+export type BidirectionalCustomCommand<T> = {
+  /**
+   * The name of the command, used to invoke it. Should be unique and descriptive in the context of the LLM.
+   */
+  name: string;
+  /**
+   * A short description of the command, used to help the LLM understand its purpose.
+   */
+  description?: string;
+} & (
+  | {
+      /**
+       * An array of values that the user can select from when invoking the command.
+       * {@label VALUES}
+       */
+      values: T[];
+      /**
+       * The command can take multiple values.
+       */
+      multipleValues: true;
+      /**
+       * A handler that will be called with the selected values when the command is invoked.
+       */
+      handler: (values: T[]) => void;
+    }
+  | {
+      /**
+       * An array of values that the user can select from when invoking the command.
+       * {@label VALUES}
+       */
+      values: T[];
+      /**
+       * The command cannot take multiple values.
+       */
+      multipleValues?: false;
+      /**
+       * A handler that will be called with the selected value when the command is invoked.
+       */
+      handler: (value: T) => void;
+    }
+  | {
+      /**
+       * A handler that will be called.
+       */
+      handler: () => void;
+    }
+);
+
+/**
+ * A type that represents a collection of custom commands, where each command can have a different type of value.
+ */
+export type BidirectionalCustomCommands<T extends unknown[]> = {
+  [I in keyof T]: BidirectionalCustomCommand<T[I]>;
+};

--- a/packages/touchpoint-ui/src/preview.tsx
+++ b/packages/touchpoint-ui/src/preview.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/require-param */
 /* eslint-disable jsdoc/require-returns */
 import { type FC, type ReactNode } from "react";
-import type { ColorMode, Theme } from "./types";
+import type { ColorMode, Theme } from "./interface";
 import { CustomPropertiesContainer } from "./components/Theme";
 import cssRaw from "./index.css?inline";
 /**

--- a/packages/touchpoint-ui/src/types.ts
+++ b/packages/touchpoint-ui/src/types.ts
@@ -1,7 +1,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import type { Config } from "@nlxai/core";
 import type { TouchpointConfiguration } from "./interface";
-import type { InteractiveElementInfo } from "./bidirectional/analyzePageForms";
 
 export type NormalizedTouchpointConfiguration = TouchpointConfiguration &
   Required<
@@ -22,22 +21,4 @@ export interface DowncastCustomCommand {
   values?: any[];
   multipleValues?: boolean;
   handler: (arg: any) => void;
-}
-
-export interface PageState {
-  formElements: Record<string, Element>;
-  links: Record<string, string>;
-  customCommands: Map<string, { values: any[]; handler: (arg: any) => void }>;
-}
-
-export interface BidirectionalContext {
-  uri?: string;
-  fields?: InteractiveElementInfo[];
-  destinations?: string[];
-  actions?: Array<{
-    name: string;
-    description?: string;
-    values?: any[];
-    multipleValues?: boolean;
-  }>;
 }

--- a/packages/touchpoint-ui/src/types.ts
+++ b/packages/touchpoint-ui/src/types.ts
@@ -1,359 +1,8 @@
-import type {
-  Config,
-  ApplicationMessage,
-  ConversationHandler,
-  Context,
-} from "@nlxai/core";
-import { type ComponentType } from "react";
+/* eslint-disable jsdoc/require-jsdoc */
+import type { Config } from "@nlxai/core";
+import type { TouchpointConfiguration } from "./interface";
+import type { InteractiveElementInfo } from "./bidirectional/analyzePageForms";
 
-/**
- * Window size configuration
- */
-export type WindowSize = "half" | "full";
-
-/**
- * Color mode configuration (light/dark modes)
- */
-export type ColorMode = "light" | "dark";
-
-/**
- * Choice message with metadata
- */
-export interface ChoiceMessage {
-  /**
-   * Message contents
-   */
-  message: ApplicationMessage;
-  /**
-   * Index in the response transcript history
-   */
-  responseIndex: number;
-  /**
-   * Message index in the current response
-   */
-  messageIndex: number;
-}
-
-/**
- * Custom Modalities allow rendering of rich components from nodes.
- * See: https://docs.studio.nlx.ai/build/resources/modalities
- */
-export type CustomModalityComponent<Data> = ComponentType<{
-  /**
-   * The payload of the Custom Modality. The schema is defined in Dialog Studio settings.
-   */
-  data: Data;
-  /**
-   * Conversation handler instance
-   */
-  conversationHandler: ConversationHandler;
-
-  /**
-   * Whether the component is enabled
-   * We should probably use context and handle disabling interactive components automatically for the user
-   * @internal
-   */
-  enabled: boolean;
-  /**
-   * Class name to propagate to the container
-   */
-  className?: string;
-}>;
-
-/**
- * The full theme expressed as CSS custom properties
- */
-export interface Theme {
-  /**
-   * Font family
-   */
-  fontFamily: string;
-
-  /**
-   * Primary color with 80% opacity
-   */
-  primary80: string;
-  /**
-   * Primary color with 60% opacity
-   */
-  primary60: string;
-  /**
-   * Primary color with 40% opacity
-   */
-  primary40: string;
-  /**
-   * Primary color with 20% opacity
-   */
-  primary20: string;
-  /**
-   * Primary color with 10% opacity
-   */
-  primary10: string;
-  /**
-   * Primary color with 5% opacity
-   */
-  primary5: string;
-  /**
-   * Primary color with 1% opacity
-   */
-  primary1: string;
-
-  /**
-   * Secondary color with 80% opacity
-   */
-  secondary80: string;
-  /**
-   * Secondary color with 60% opacity
-   */
-  secondary60: string;
-  /**
-   * Secondary color with 40% opacity
-   */
-  secondary40: string;
-  /**
-   * Secondary color with 20% opacity
-   */
-  secondary20: string;
-  /**
-   * Secondary color with 10% opacity
-   */
-  secondary10: string;
-  /**
-   * Secondary color with 5% opacity
-   */
-  secondary5: string;
-  /**
-   * Secondary color with 1% opacity
-   */
-  secondary1: string;
-
-  /**
-   * Accent color used e.g. for prominent buttons, the loader animation as well as selected card outlines
-   */
-  accent: string;
-  /**
-   * Accent color with 20% opacity
-   */
-  accent20: string;
-  /**
-   * The background color of the main Touchpoint interface
-   */
-  background: string;
-  /**
-   * The color of the overlay covering the visible portion of the website when the Touchpoint interface does not cover the full screen
-   */
-  overlay: string;
-
-  /**
-   * Primary warning color
-   */
-  warningPrimary: string;
-  /**
-   * Secondary warning color
-   */
-  warningSecondary: string;
-  /**
-   * Primary error color
-   */
-  errorPrimary: string;
-  /**
-   * Secondary error color
-   */
-  errorSecondary: string;
-
-  /**
-   * Inner border radius: used for most buttons
-   */
-  innerBorderRadius: string;
-  /**
-   * Outer border radius: generally used for elements that contain buttons that have inner border radius. Also used by the launch button.
-   */
-  outerBorderRadius: string;
-}
-
-/**
- * Custom conversation init method. Defaults to sending the welcome intent
- * @param handler - the conversation handler.
- * @param context - context set via TouchpointConfiguration.initialContext
- */
-export type InitializeConversation = (
-  handler: ConversationHandler,
-  context?: Context,
-) => void;
-
-/**
- * Fully custom launch icon
- */
-export type CustomLaunchButton = ComponentType<{
-  /**
-   * Class name injected into the component mainly to take care of positioning and z-index. Can be combined with more presentational and sizing-related class names.
-   */
-  className?: string;
-  /**
-   * Click handler that expands Touchpoint, without the caller having to implement this based on Touchpoint instance methods.
-   */
-  onClick?: () => void;
-}>;
-
-/**
- * Input type for the experience
- */
-export type Input = "text" | "voice" | "voiceMini";
-
-/**
- * Configuration for bidirectional mode of voice+.
- */
-export type BidirectionalConfig =
-  | {
-      /**
-       * Attempt to gather and send page context automatically. This will work well on semantically coded pages without too many custom form controls.
-       * This enables a number of automatic features.
-       *
-       * Defaults to `true`.
-       */
-      automaticContext?: true;
-
-      /**
-       * Navigation handler for bidirectional mode.
-       *
-       * If automatic context gathering is enabled, the default implementation will navigate to those pages using standard `window.location` APIs.
-       * @param action - The navigation action to perform.
-       * @param destination - The name of the destination to navigate to if `action` is `"page_custom"`.
-       * @param destinations - A map of destination names to URLs for custom navigation. Only present if `automaticContext` is enabled.
-       */
-      navigation?: (
-        action: "page_next" | "page_previous" | "page_custom" | "page_unknown",
-        destination: string | undefined,
-        destinations: Record<string, string>,
-      ) => void;
-
-      /**
-       * A callback for filling out form fields in bidirectional mode.
-       *
-       * If automatic context gathering is enabled, the default implementation will fill out the form fields using standard DOM APIs.
-       * @param fields - An array of field objects with `id` and `value` properties.
-       * @param pageFields - A map of field IDs to DOM elements for custom form filling. Only present if `automaticContext` is enabled.
-       */
-      input?: (
-        fields: Array<{ id: string; value: string }>,
-        pageFields: Record<string, Element>,
-      ) => void;
-
-      /**
-       * A callback for custom actions in bidirectional mode.
-       * @param action - The custom name of your action.
-       * @param payload - The payload defined for the custom action.
-       * @returns
-       */
-      custom?: (action: string, payload: unknown) => void;
-    }
-  | {
-      /**
-       * Attempt to gather and send page context automatically. This will work well on semantically coded pages without too many custom form controls.
-       * This enables a number of automatic features.
-       *
-       * Defaults to `true`.
-       */
-      automaticContext: false;
-
-      /**
-       * Navigation handler for bidirectional mode.
-       *
-       * If automatic context gathering is enabled, the default implementation will navigate to those pages using standard `window.location` APIs.
-       * @param action - The navigation action to perform.
-       * @param destination - The name of the destination to navigate to if `action` is `"page_custom"`.
-       */
-      navigation?: (
-        action: "page_next" | "page_previous" | "page_custom" | "page_unknown",
-        destination?: string,
-      ) => void;
-      /**
-       * A callback for filling out form fields in bidirectional mode.
-       *
-       * If automatic context gathering is enabled, the default implementation will fill out the form fields using standard DOM APIs.
-       * @param fields - An array of field objects with `id` and `value` properties.
-       */
-      input?: (fields: Array<{ id: string; value: string }>) => void;
-      /**
-       * A callback for custom actions in bidirectional mode.
-       * @param action - The custom name of your action.
-       * @param payload - The payload defined for the custom action.
-       * @returns
-       */
-      custom?: (action: string, payload: unknown) => void;
-    };
-
-/**
- * Main Touchpoint creation properties object
- */
-export interface TouchpointConfiguration {
-  /**
-   * Connection information for the \@nlxai/core conversation handler
-   */
-  config: Config;
-  /**
-   * Optional window size for the chat window, defaults to `half`
-   */
-  windowSize?: WindowSize;
-  /**
-   * Optional color mode for the chat window, defaults to `dark`
-   */
-  colorMode?: ColorMode;
-  /**
-   * URL of icon used to display the brand in the chat header
-   */
-  brandIcon?: string;
-  /**
-   * URL of icon used on the launch icon in the bottom right when the experience is collapsed.
-   *
-   * When set to `false`, no launch button is shown at all. When not set or set to `true`, the default launch icon is rendered.
-   */
-  launchIcon?: string | boolean | CustomLaunchButton;
-  /**
-   * Specifies whether the user message has bubbles or not
-   */
-  userMessageBubble?: boolean;
-  /**
-   * Specifies whether the agent message has bubbles or not
-   */
-  agentMessageBubble?: boolean;
-  /**
-   * Enables chat mode, a classic chat experience with inline loaders and the chat history visible at all times.
-   */
-  chatMode?: boolean;
-  /**
-   * Optional theme object to override default theme values
-   */
-  theme?: Partial<Theme>;
-  /**
-   * Optional custom modality components to render in Touchpoint
-   */
-  customModalities?: Record<string, CustomModalityComponent<unknown>>;
-  /**
-   * Custom conversation init method. Defaults to sending the welcome intent
-   * @param handler - the conversation handler.
-   * @param context - the context object
-   */
-  initializeConversation?: InitializeConversation;
-  /**
-   * Controls the ways in which  the user can communicate with the application. Defaults to `"text"`
-   */
-  input?: Input;
-  /**
-   * Context sent with the initial request.
-   */
-  initialContext?: Context;
-
-  /**
-   * Enables bidirectional mode of voice+. Will automatically set the bidirectional flag in the config.
-   *
-   */
-  bidirectional?: BidirectionalConfig;
-}
-
-/**
- * @internal
- */
 export type NormalizedTouchpointConfiguration = TouchpointConfiguration &
   Required<
     Pick<TouchpointConfiguration, "initializeConversation" | "input">
@@ -362,3 +11,33 @@ export type NormalizedTouchpointConfiguration = TouchpointConfiguration &
       Pick<Config, "conversationId" | "userId" | "bidirectional">
     >;
   };
+
+/**
+ * Less type safe version of {@link BidirectionalCustomCommand}, but makes your life easier since it doesn't require generic arguments to be spammed everywhere.
+ * @internal
+ */
+export interface DowncastCustomCommand {
+  name: string;
+  description?: string;
+  values?: any[];
+  multipleValues?: boolean;
+  handler: (arg: any) => void;
+}
+
+export interface PageState {
+  formElements: Record<string, Element>;
+  links: Record<string, string>;
+  customCommands: Map<string, { values: any[]; handler: (arg: any) => void }>;
+}
+
+export interface BidirectionalContext {
+  uri?: string;
+  fields?: InteractiveElementInfo[];
+  destinations?: string[];
+  actions?: Array<{
+    name: string;
+    description?: string;
+    values?: any[];
+    multipleValues?: boolean;
+  }>;
+}

--- a/packages/touchpoint-ui/tsdoc.json
+++ b/packages/touchpoint-ui/tsdoc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["typedoc/tsdoc.json"],
+  "noStandardTags": false,
+  "tagDefinitions": []
+}


### PR DESCRIPTION
Adds:

- `ToucpointInstance.setCustomBidirectionalCommands` for automatic context bidi mode. 
- `config.bidirectional.customizeAutomaticContext` option for customizing what the automatic context does. I think we've seen the use for this kind of function before - where the automatic mode does 90% of what you need, but there is some small feature you'd like to cover.
- Automatic context now sends the `uri` parameter automatically.