### PR TITLE
Fix double comma

### DIFF
--- a/packages/website/src/snippets.ts
+++ b/packages/website/src/snippets.ts
@@ -153,17 +153,17 @@ export const touchpointUiSetupSnippet = ({
   input: "${input}",${
     theme != null
       ? `
-  theme: ${JSON.stringify(theme)}`
+  theme: ${JSON.stringify(theme)},`
       : ""
-  },${
+  }${
     templateComponents === "museumComponents"
       ? `
-  customModalities: { MuseumExhibitDetails, MuseumExhibitCarousel }`
+  customModalities: { MuseumExhibitDetails, MuseumExhibitCarousel },`
       : ""
-  },${
+  }${
     input === "voiceMini" && bidirectional
       ? `
-  bidirectional: {}`
+  bidirectional: {},`
       : ""
   }
 });`;


### PR DESCRIPTION
We previously had this:

<img width="2494" height="1774" alt="CleanShot 2025-08-31 at 09 51 01@2x" src="https://github.com/user-attachments/assets/fe8e39cb-fb04-46e4-9d5e-96ef4f9c9797" />
