### PR TITLE
Keep cli private

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,6 @@
   },
   "npmClient": "npm",
   "packages": [
-    "packages/cli",
     "packages/core",
     "packages/voice-plus-core",
     "packages/voice-plus-web",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nlxai/cli",
+  "private": true,
   "version": "1.1.8-alpha.3",
   "description": "Tools for integrating with NLX apps",
   "keywords": [


### PR DESCRIPTION
Either we do this or add `publishConfig: { access: "public" }` to the `@nlxai/cli`'s `package.json`, otherwise publishing keeps erroring out. I think we can start getting this live, but opinions welcome.