### PR TITLE
Rive anim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3883,6 +3883,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rive-app/webgl2": {
+      "version": "2.31.5",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.31.5.tgz",
+      "integrity": "sha512-yBCyWogdlD8otlT9V7UzIEvpbL5HEtuaxAMJvUcx2vUmLXp52C45H+G9/RvK98e0r3WcEDM2aNQzTjNZE9UrOA==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.7",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
@@ -22532,6 +22538,7 @@
         "@nlxai/core": "^1.1.8-alpha.0",
         "@react-hookz/web": "^25.0.1",
         "@react-input/mask": "^2.0.4",
+        "@rive-app/webgl2": "^2.31.5",
         "@types/json-schema": "^7.0.15",
         "clsx": "^2.1.1",
         "htm": "^3.1.1",

--- a/packages/touchpoint-ui/package.json
+++ b/packages/touchpoint-ui/package.json
@@ -27,6 +27,7 @@
     "@nlxai/core": "^1.1.8-alpha.0",
     "@react-hookz/web": "^25.0.1",
     "@react-input/mask": "^2.0.4",
+    "@rive-app/webgl2": "^2.31.5",
     "@types/json-schema": "^7.0.15",
     "clsx": "^2.1.1",
     "htm": "^3.1.1",

--- a/packages/touchpoint-ui/src/App.tsx
+++ b/packages/touchpoint-ui/src/App.tsx
@@ -346,7 +346,7 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
   if (input === "voiceMini") {
     return (
       <>
-        <RiveAnimation />
+        {props.animate ? <RiveAnimation /> : null}
         <CustomPropertiesContainer
           theme={props.theme}
           colorMode={colorMode}

--- a/packages/touchpoint-ui/src/App.tsx
+++ b/packages/touchpoint-ui/src/App.tsx
@@ -39,6 +39,7 @@ import { CustomPropertiesContainer } from "./components/Theme";
 import { VoiceMini } from "./components/VoiceMini";
 import { gatherAutomaticContext } from "./bidirectional/automaticContext";
 import { commandHandler } from "./bidirectional/commandHandler";
+import { RiveAnimation } from "./components/RiveAnimation";
 
 /**
  * Main Touchpoint creation properties object
@@ -344,25 +345,28 @@ const App = forwardRef<AppRef, Props>((props, ref) => {
 
   if (input === "voiceMini") {
     return (
-      <CustomPropertiesContainer
-        theme={props.theme}
-        colorMode={colorMode}
-        className={clsx(
-          "w-fit",
-          props.embedded ? "" : "fixed z-touchpoint bottom-2 right-2",
-        )}
-      >
-        <VoiceMini
-          key={voiceKey}
-          handler={handler}
-          context={props.initialContext}
-          onClose={() => {
-            onClose(new Event("close"));
-          }}
-          renderCollapse={props.onClose != null}
-          customModalities={customModalities}
-        />
-      </CustomPropertiesContainer>
+      <>
+        <RiveAnimation />
+        <CustomPropertiesContainer
+          theme={props.theme}
+          colorMode={colorMode}
+          className={clsx(
+            "w-fit",
+            props.embedded ? "" : "fixed z-touchpoint bottom-2 right-2",
+          )}
+        >
+          <VoiceMini
+            key={voiceKey}
+            handler={handler}
+            context={props.initialContext}
+            onClose={() => {
+              onClose(new Event("close"));
+            }}
+            renderCollapse={props.onClose != null}
+            customModalities={customModalities}
+          />
+        </CustomPropertiesContainer>
+      </>
     );
   }
 

--- a/packages/touchpoint-ui/src/components/RiveAnimation.tsx
+++ b/packages/touchpoint-ui/src/components/RiveAnimation.tsx
@@ -1,0 +1,52 @@
+import { type FC, useEffect, useRef } from "react";
+import { Rive, Layout, Fit } from "@rive-app/webgl2";
+
+export const RiveAnimation: FC<unknown> = () => {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (canvas == null) {
+      return;
+    }
+    const riveInstance = new Rive({
+      src: "https://assets.nlx.ai/touchpoint/voice-plus-animation.riv",
+      canvas,
+      autoBind: true,
+      autoplay: true,
+      stateMachines: "State Machine 1",
+      layout: new Layout({
+        fit: Fit.Fill,
+      }),
+      onLoad: () => {
+        riveInstance.resizeDrawingSurfaceToCanvas();
+        const vmi = riveInstance.viewModelInstance;
+        if (vmi != null) {
+          const run = vmi.trigger("run");
+          if (run != null) {
+            run.trigger();
+          }
+        }
+      },
+    });
+
+    const handleResize = (): void => {
+      riveInstance.resizeDrawingSurfaceToCanvas();
+    };
+
+    window.addEventListener("resize", handleResize, false);
+
+    return () => {
+      riveInstance.cleanup();
+      window.removeEventListener("resize", handleResize, false);
+    };
+  }, []);
+
+  return (
+    <canvas
+      className="pointer-events-none fixed inset-0"
+      ref={ref}
+      style={{ width: "100%", height: "100%" }}
+    />
+  );
+};

--- a/packages/touchpoint-ui/src/interface.ts
+++ b/packages/touchpoint-ui/src/interface.ts
@@ -376,6 +376,10 @@ export interface TouchpointConfiguration {
    */
   brandIcon?: string;
   /**
+   * Include border animation. Currently only supported in Voice Mini.
+   */
+  animate?: boolean;
+  /**
    * URL of icon used on the launch icon in the bottom right when the experience is collapsed.
    *
    * When set to `false`, no launch button is shown at all. When not set or set to `true`, the default launch icon is rendered.


### PR DESCRIPTION
When adding the `animate: true` top-level configuration, voice mini experiences now include the rive animation by default:

https://github.com/user-attachments/assets/35ae5bf2-cb7e-4909-9a63-3b16348de266

