### PR TITLE
Set default font to system

### DIFF
--- a/packages/touchpoint-ui/src/components/Theme.tsx
+++ b/packages/touchpoint-ui/src/components/Theme.tsx
@@ -40,7 +40,8 @@ const toCustomProperties = (theme: Theme): CSSProperties => {
 };
 
 const customProperties: Theme = {
-  fontFamily: '"Neue Haas Grotesk", sans-serif',
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
   innerBorderRadius: "12px",
   outerBorderRadius: "20px",
 


### PR DESCRIPTION
The current default is bad because the font is not imported so users will just see `sans-serif`.