### PR TITLE
use adoptedstylesheets

### DIFF
--- a/packages/touchpoint-ui/__tests__/adoptPropertyDeclarations.test.ts
+++ b/packages/touchpoint-ui/__tests__/adoptPropertyDeclarations.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { extractPropertyCSS } from "../src/adoptPropertyDeclarations";
+
+const sampleCSS = `
+  .foo { color: red; }
+  @property --tw-translate-x { syntax: "*"; inherits: false; initial-value: 0 }
+  .bar { display: flex; }
+  @property --glow-opacity { syntax: "<percentage>"; inherits: false; initial-value: 0% }
+`;
+
+describe("extractPropertyCSS", () => {
+  it("extracts only @property declarations from the CSS", () => {
+    const result = extractPropertyCSS(sampleCSS);
+    expect(result).toContain("@property --tw-translate-x");
+    expect(result).toContain("@property --glow-opacity");
+    expect(result).not.toContain(".foo");
+    expect(result).not.toContain(".bar");
+  });
+
+  it("returns null when no @property declarations are present", () => {
+    expect(extractPropertyCSS(".foo { color: red; }")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(extractPropertyCSS("")).toBeNull();
+  });
+});

--- a/packages/touchpoint-ui/src/adoptPropertyDeclarations.ts
+++ b/packages/touchpoint-ui/src/adoptPropertyDeclarations.ts
@@ -1,0 +1,37 @@
+const atPropertyRe = /@property\s+[^{]+\{[^}]*\}/g;
+
+/**
+ * Extracts all `@property` declarations from a CSS string, returning only
+ * those rules joined as a single stylesheet string. Returns `null` when the
+ * input contains no `@property` rules.
+ */
+export const extractPropertyCSS = (css: string): string | null => {
+  const matches = css.match(atPropertyRe);
+  if (matches == null || matches.length === 0) return null;
+  return matches.join("\n");
+};
+
+let adopted = false;
+
+/**
+ * Extracts `@property` declarations from a CSS string and adopts them into the
+ * document so they are registered at the top level.
+ *
+ * `@property` rules are silently ignored inside shadow roots. By adopting a
+ * stylesheet containing **only** `@property` declarations at the document level,
+ * we register custom properties (e.g. Tailwind v4's `--tw-translate-x`) without
+ * leaking utility classes or other styles into the host page.
+ *
+ * Idempotent — subsequent calls are a no-op.
+ */
+export const adoptPropertyDeclarations = (css: string): void => {
+  if (adopted) return;
+  adopted = true;
+
+  const propertyCSS = extractPropertyCSS(css);
+  if (propertyCSS == null) return;
+
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(propertyCSS);
+  document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+};

--- a/packages/touchpoint-ui/src/components/FullscreenVoice.tsx
+++ b/packages/touchpoint-ui/src/components/FullscreenVoice.tsx
@@ -339,7 +339,7 @@ export const FullscreenVoice: FC<Props> = ({
         modalityComponents={modalityComponents}
         handler={handler}
       />
-      <div className="w-fit flex-none absolute bottom-4 left-1/2 transform -translate-x-1/2 translate-y-0">
+      <div className="w-fit flex-none absolute bottom-4 left-1/2 transform -translate-x-1/2">
         {voice.state?.isUserSpeaking ? (
           <Ripple className="rounded-inner" />
         ) : null}

--- a/packages/touchpoint-ui/src/components/Header.tsx
+++ b/packages/touchpoint-ui/src/components/Header.tsx
@@ -44,7 +44,7 @@ export const Header: FC<HeaderProps> = ({
   return (
     <div
       className={clsx("flex p-2 md:p-3 items-center justify-between gap-2", {
-        "md:absolute md:w-fit md:flex-col md:left-0 md:transform md:-translate-x-full md:translate-y-0":
+        "md:absolute md:w-fit md:flex-col md:left-0 md:transform md:-translate-x-full":
           windowSize === "half",
         "@3xl/main:absolute @3xl/main:left-0 @3xl/main:right-0 @3xl/main:top-0":
           windowSize === "full" || windowSize === "embedded",

--- a/packages/touchpoint-ui/src/components/VoiceMini.tsx
+++ b/packages/touchpoint-ui/src/components/VoiceMini.tsx
@@ -222,7 +222,7 @@ export const VoiceMini: FC<{
       <VoiceModalities
         className={clsx(
           containerClass,
-          "absolute right-0 -top-2 transform translate-x-0 -translate-y-full max-h-[360px] overflow-auto",
+          "absolute right-0 -top-2 transform -translate-y-full max-h-[360px] overflow-auto",
         )}
         responses={responses}
         renderedAsOverlay={false}

--- a/packages/touchpoint-ui/src/index.tsx
+++ b/packages/touchpoint-ui/src/index.tsx
@@ -6,6 +6,7 @@ import { equals } from "ramda";
 import packageJson from "../package.json";
 import App, { type AppRef } from "./App";
 import cssRaw from "./index.css?inline";
+import { adoptPropertyDeclarations } from "./adoptPropertyDeclarations";
 import * as Icons from "./components/ui/Icons";
 import { TextButton } from "./components/ui/TextButton";
 import { IconButton } from "./components/ui/IconButton";
@@ -282,6 +283,7 @@ class NlxTouchpointElement extends HTMLElement {
   #render(): void {
     this.#shadowRoot ??= this.attachShadow({ mode: "closed" });
     this.#root ??= createRoot(this.#shadowRoot);
+    adoptPropertyDeclarations(cssRaw);
     if (this.#touchpointConfiguration != null) {
       const configuration = normalizeConfiguration(
         this.#touchpointConfiguration,


### PR DESCRIPTION
# adoptedStyleSheets migration

## The problem

Tailwind v4 uses [`@property`](https://developer.mozilla.org/en-US/docs/Web/CSS/@property) to register CSS custom properties with explicit types and initial values — for example `--tw-translate-x` with `initial-value: 0`. **`@property` declarations are silently ignored inside a shadow root.** They must be registered at the document level.

Previously the compiled Tailwind CSS was injected as a `<style>` tag inside the closed shadow root, which broke all `@property`-dependent utilities. The codebase worked around this with redundant zero-value translate classes:

```tsx
"md:transform md:-translate-x-full md:translate-y-0"  // translate-y-0 is the workaround
"transform translate-x-0 -translate-y-full ..."        // translate-x-0 is the workaround
```

This isn't just an aesthetic/verbosity problem with the current codebase. We spent a couple of hours debugging this already, so it's a mainteinance concern.

## The fix

Share a single `CSSStyleSheet` across both the shadow root and the document.

```ts
const sheet = new CSSStyleSheet();
sheet.replaceSync(cssRaw);

// in #render():
this.#shadowRoot.adoptedStyleSheets = [sheet];
if (!document.adoptedStyleSheets.includes(sheet)) {
  document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
}
```

The redundant zero-value workaround classes were also removed from `Header.tsx`, `VoiceMini.tsx`, and `FullscreenVoice.tsx`.

## Visual comparison (`windowSize: "half"`)

The header controls should float outside the chat panel to the left via `md:-translate-x-full`.

**Before** — buttons stuck inside the panel, overlapping content:

<img width="1280" height="720" alt="adopted-stylesheets-before" src="https://github.com/user-attachments/assets/e26ea8d4-8d2e-47d3-b69f-91439066e7d6" />

**After** — buttons correctly positioned in the overlay area:
<img width="1280" height="720" alt="adopted-stylesheets-after" src="https://github.com/user-attachments/assets/c78c5338-96c4-4617-bdbf-40bb3c2071db" />


## Notes on `@property` collisions

- **Tailwind v3** does not use `@property` at all 
- **Tailwind v4 on the same page**: the only realistic collision scenario. Harmless in practice: all Tailwind v4 installs generate identical registrations for the same property names.
- **Other frameworks** — very very unlikely to register `--tw-*` properties. If it ever became a concern, we could do css post-processing and prefix our properties with `nlx:`