### PR TITLE
Connect customer adapter adjustments

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,6 +10,7 @@
   "npmClient": "npm",
   "packages": [
     "packages/core",
+    "packages/connect-chat-adapter",
     "packages/voice-plus-web",
     "packages/touchpoint-ui",
     "packages/cli"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,7 +1279,6 @@
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1293,7 +1292,6 @@
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -1328,7 +1326,6 @@
     "node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1344,7 +1341,6 @@
     "node_modules/@jest/types/node_modules/@jest/schemas": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1354,8 +1350,7 @@
     },
     "node_modules/@jest/types/node_modules/@sinclair/typebox": {
       "version": "0.27.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -3139,7 +3134,6 @@
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -3147,7 +3141,6 @@
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -3319,7 +3312,6 @@
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3464,13 +3456,11 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -3478,7 +3468,6 @@
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -3486,7 +3475,6 @@
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -3496,7 +3484,6 @@
     "node_modules/@types/jsdom/node_modules/entities": {
       "version": "6.0.1",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3507,7 +3494,6 @@
     "node_modules/@types/jsdom/node_modules/parse5": {
       "version": "7.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -3589,8 +3575,7 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/tinycolor2": {
       "version": "1.4.6",
@@ -3599,8 +3584,7 @@
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -3615,15 +3599,13 @@
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",
@@ -4238,8 +4220,7 @@
     },
     "node_modules/abab": {
       "version": "2.0.6",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/abbrev": {
       "version": "3.0.1",
@@ -4262,7 +4243,6 @@
     "node_modules/acorn-globals": {
       "version": "7.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -4278,7 +4258,6 @@
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -4360,8 +4339,9 @@
     },
     "node_modules/amazon-connect-chatjs": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/amazon-connect-chatjs/-/amazon-connect-chatjs-2.3.2.tgz",
+      "integrity": "sha512-0IA/fnKWsgx70Qq9UKTZpEJMmUizM+TdfCQT7n/FNbsjt99wd+CdSI8OHVmPU6ZLsy1kRAKGIvC/GJC3Hh301Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "detect-browser": "5.3.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -4374,8 +4354,7 @@
     },
     "node_modules/amazon-connect-chatjs/node_modules/sprintf-js": {
       "version": "1.1.3",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/anchor-markdown-header": {
       "version": "0.8.4",
@@ -5789,8 +5768,7 @@
     },
     "node_modules/cssom": {
       "version": "0.5.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "5.3.7",
@@ -6109,8 +6087,7 @@
     },
     "node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -6203,7 +6180,6 @@
     "node_modules/domexception": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
       },
@@ -6214,7 +6190,6 @@
     "node_modules/domexception/node_modules/webidl-conversions": {
       "version": "7.0.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6687,7 +6662,6 @@
     "node_modules/escodegen": {
       "version": "2.1.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -9010,7 +8984,6 @@
     "node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -9036,7 +9009,6 @@
     "node_modules/jest-environment-jsdom/node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -9047,7 +9019,6 @@
     "node_modules/jest-environment-jsdom/node_modules/cssstyle": {
       "version": "2.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -9057,13 +9028,11 @@
     },
     "node_modules/jest-environment-jsdom/node_modules/cssstyle/node_modules/cssom": {
       "version": "0.3.8",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-environment-jsdom/node_modules/data-urls": {
       "version": "3.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -9076,7 +9045,6 @@
     "node_modules/jest-environment-jsdom/node_modules/entities": {
       "version": "6.0.1",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -9087,7 +9055,6 @@
     "node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
       },
@@ -9098,7 +9065,6 @@
     "node_modules/jest-environment-jsdom/node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -9111,7 +9077,6 @@
     "node_modules/jest-environment-jsdom/node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -9123,7 +9088,6 @@
     "node_modules/jest-environment-jsdom/node_modules/jsdom": {
       "version": "20.0.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -9167,7 +9131,6 @@
     "node_modules/jest-environment-jsdom/node_modules/parse5": {
       "version": "7.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -9178,7 +9141,6 @@
     "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
       "version": "4.1.4",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -9192,7 +9154,6 @@
     "node_modules/jest-environment-jsdom/node_modules/tr46": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -9203,7 +9164,6 @@
     "node_modules/jest-environment-jsdom/node_modules/universalify": {
       "version": "0.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -9211,7 +9171,6 @@
     "node_modules/jest-environment-jsdom/node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
@@ -9222,7 +9181,6 @@
     "node_modules/jest-environment-jsdom/node_modules/webidl-conversions": {
       "version": "7.0.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9230,7 +9188,6 @@
     "node_modules/jest-environment-jsdom/node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9238,7 +9195,6 @@
     "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
       "version": "11.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
@@ -9250,7 +9206,6 @@
     "node_modules/jest-environment-jsdom/node_modules/xml-name-validator": {
       "version": "4.0.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9258,7 +9213,6 @@
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -9277,7 +9231,6 @@
     "node_modules/jest-message-util/node_modules/@jest/schemas": {
       "version": "29.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -9287,13 +9240,11 @@
     },
     "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
       "version": "0.27.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
       "version": "5.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9304,7 +9255,6 @@
     "node_modules/jest-message-util/node_modules/pretty-format": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -9317,7 +9267,6 @@
     "node_modules/jest-mock": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -9330,7 +9279,6 @@
     "node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -9352,7 +9300,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9360,7 +9307,6 @@
     "node_modules/jest-util/node_modules/picomatch": {
       "version": "2.3.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -9949,8 +9895,7 @@
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -11250,8 +11195,7 @@
     },
     "node_modules/nwsapi": {
       "version": "2.2.24",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nx": {
       "version": "22.7.5",
@@ -12513,7 +12457,6 @@
     "node_modules/psl": {
       "version": "1.15.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -12561,8 +12504,7 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -13026,8 +12968,7 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -13730,7 +13671,6 @@
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -13741,7 +13681,6 @@
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -14617,7 +14556,6 @@
     "node_modules/type-detect": {
       "version": "4.0.8",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14986,7 +14924,6 @@
     "node_modules/url-parse": {
       "version": "1.5.10",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -15398,7 +15335,6 @@
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -15409,7 +15345,6 @@
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -16106,7 +16041,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@nlxai/core": "^1.2.6"
+        "@nlxai/core": "^1.2.6",
+        "amazon-connect-chatjs": "^2.3.2"
       },
       "devDependencies": {
         "@nlxai/eslint-config": "*",
@@ -16120,9 +16056,6 @@
         "@types/node": "^24.10.1",
         "rollup": "^4.59.0",
         "typescript": "^5.5.4"
-      },
-      "peerDependencies": {
-        "amazon-connect-chatjs": "^2.0.0"
       },
       "peerDependenciesMeta": {
         "amazon-connect-chatjs": {

--- a/packages/connect-chat-adapter/eslint.config.js
+++ b/packages/connect-chat-adapter/eslint.config.js
@@ -1,0 +1,5 @@
+import baseConfig from "@nlxai/eslint-config";
+import documentation from "@nlxai/eslint-config/documentation";
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [...baseConfig, ...documentation];

--- a/packages/connect-chat-adapter/package.json
+++ b/packages/connect-chat-adapter/package.json
@@ -37,10 +37,8 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@nlxai/core": "^1.2.6"
-  },
-  "peerDependencies": {
-    "amazon-connect-chatjs": "^2.0.0"
+    "@nlxai/core": "^1.2.6",
+    "amazon-connect-chatjs": "^2.3.2"
   },
   "peerDependenciesMeta": {
     "amazon-connect-chatjs": {

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -79,7 +79,9 @@ export const fetchChatDetails = async (
   const body: Record<string, unknown> = {
     InstanceId: params.instanceId,
     ContactFlowId: params.contactFlowId,
-    DisplayName: params.participantDisplayName,
+    ParticipantDetails: {
+      DisplayName: params.participantDisplayName,
+    },
     Attributes: params.contactAttributes,
     SupportedMessagingContentTypes: params.supportedMessagingContentTypes ?? [
       "text/plain",
@@ -101,7 +103,7 @@ export const fetchChatDetails = async (
 
   const data = await res.json();
   // The CloudFormation-deployed Lambda returns: { data: { startChatResult: { ContactId, ParticipantId, ParticipantToken } } }
-  const startChatResult = data?.data?.startChatResult ?? data?.data ?? data;
+  const startChatResult = data?.data?.startChatResult;
   return {
     contactId: startChatResult.ContactId ?? startChatResult.contactId,
     participantId:

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -69,7 +69,7 @@ export interface DetailsParams {
 }
 
 /**
- *
+ * Fetch chat details via API Gateway endpoint
  */
 export const fetchChatDetails = async (
   endpoint: string,

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -21,55 +21,11 @@ import { ResponseType } from "@nlxai/core";
  * No AWS access keys or secret keys are required client-side. Authentication
  * is handled via the participant token returned by the StartChatContact API.
  *
- * There are two ways to obtain chat details:
- *
- * 1. **Use `startChatEndpoint`** (recommended) — provide the URL of your API Gateway
- *    endpoint (deployed via the AWS-provided CloudFormation template). The adapter
- *    calls it automatically to start the chat.
- *
- * 2. **Use `chatDetails` directly** — if you've already called StartChatContact
- *    yourself, pass the response directly.
+ * Chat details are obtained via the `fetchChatDetails` call.
  */
 export interface ConnectChatConfig {
-  /**
-   * URL of the API Gateway endpoint that calls StartChatContact.
-   * This is the endpoint created by the AWS CloudFormation template for Connect Chat.
-   * When provided, the adapter automatically initiates the chat — no manual
-   * StartChatContact call is needed.
-   *
-   * Mutually exclusive with `chatDetails`.
-   */
-  startChatEndpoint?: string;
-  /**
-   * Parameters to pass when calling the `startChatEndpoint`.
-   */
-  startChatParams?: {
-    /** Connect instance ID */
-    instanceId?: string;
-    /** Contact flow ID to use */
-    contactFlowId?: string;
-    /** Customer display name */
-    participantDisplayName?: string;
-    /** Contact attributes passed to the contact flow */
-    contactAttributes?: Record<string, string>;
-    /**
-     * Content types the chat participant supports receiving.
-     * Defaults to text/plain, text/markdown, application/json, and interactive messages.
-     */
-    supportedMessagingContentTypes?: string[];
-  };
-  /**
-   * Pre-obtained chat details from a prior StartChatContact call.
-   * Mutually exclusive with `startChatEndpoint`.
-   */
-  chatDetails?: {
-    /** The contact ID */
-    contactId: string;
-    /** The participant ID */
-    participantId: string;
-    /** The participant token used for authentication */
-    participantToken: string;
-  };
+  /** Pre-obtained chat details from a prior StartChatContact call. */
+  details: ChatDetails;
   /** AWS region (e.g., "us-east-1"). Defaults to "us-west-2". */
   region?: string;
   /** Language code for the conversation */
@@ -81,11 +37,78 @@ export interface ConnectChatConfig {
   globalConfig?: Record<string, unknown>;
 }
 
-interface ResolvedChatDetails {
+/**
+ * Chat details
+ */
+export interface ChatDetails {
+  /** The contact ID */
   contactId: string;
+  /** The participant ID */
   participantId: string;
+  /** The participant token used for authentication */
   participantToken: string;
 }
+
+/**
+ * Parameters to pass when calling the `startChatEndpoint`.
+ */
+export interface DetailsParams {
+  /** Connect instance ID */
+  instanceId?: string;
+  /** Contact flow ID to use */
+  contactFlowId?: string;
+  /** Customer display name */
+  participantDisplayName?: string;
+  /** Contact attributes passed to the contact flow */
+  contactAttributes?: Record<string, string>;
+  /**
+   * Content types the chat participant supports receiving.
+   * Defaults to text/plain, text/markdown, application/json, and interactive messages.
+   */
+  supportedMessagingContentTypes?: string[];
+}
+
+/**
+ *
+ */
+export const fetchChatDetails = async (
+  endpoint: string,
+  params: DetailsParams,
+): Promise<ChatDetails> => {
+  const body: Record<string, unknown> = {
+    InstanceId: params.instanceId,
+    ContactFlowId: params.contactFlowId,
+    DisplayName: params.participantDisplayName,
+    Attributes: params.contactAttributes,
+    SupportedMessagingContentTypes: params.supportedMessagingContentTypes ?? [
+      "text/plain",
+      "text/markdown",
+      "application/json",
+      "application/vnd.amazonaws.connect.message.interactive",
+    ],
+  };
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`StartChatContact endpoint returned ${res.status}`);
+  }
+
+  const data = await res.json();
+  // The CloudFormation-deployed Lambda returns: { data: { startChatResult: { ContactId, ParticipantId, ParticipantToken } } }
+  const startChatResult = data?.data?.startChatResult ?? data?.data ?? data;
+  return {
+    contactId: startChatResult.ContactId ?? startChatResult.contactId,
+    participantId:
+      startChatResult.ParticipantId ?? startChatResult.participantId,
+    participantToken:
+      startChatResult.ParticipantToken ?? startChatResult.participantToken,
+  };
+};
 
 /**
  * Creates a ConversationHandler backed by Amazon Connect Chat via amazon-connect-chatjs.
@@ -95,10 +118,9 @@ interface ResolvedChatDetails {
  *
  * Prerequisites:
  * - `amazon-connect-chatjs` must be loaded before calling this function
- *   (via `import "amazon-connect-chatjs"` or a `<script>` tag).
+ * (via `import "amazon-connect-chatjs"` or a `<script>` tag).
  * - Either provide a `startChatEndpoint` (URL of the API Gateway from the AWS
- *   CloudFormation template) or pre-obtained `chatDetails`.
- *
+ * CloudFormation template) or pre-obtained `chatDetails`.
  * @example
  * ```typescript
  * import "amazon-connect-chatjs";
@@ -133,9 +155,9 @@ interface ResolvedChatDetails {
  * });
  * ```
  */
-export function createConnectChatConversation(
+export const createConnectChatConversation = (
   config: ConnectChatConfig,
-): ConversationHandler {
+): ConversationHandler => {
   let subscribers: Subscriber[] = [];
   let responses: Response[] = [];
   let languageCode: LanguageCode = config.languageCode ?? "en-US";
@@ -184,67 +206,10 @@ export function createConnectChatConversation(
     return connectObj;
   };
 
-  const fetchChatDetails = async (): Promise<ResolvedChatDetails> => {
-    if (config.chatDetails != null) {
-      return config.chatDetails;
-    }
-    if (config.startChatEndpoint == null) {
-      throw new Error(
-        "@nlxai/connect-chat-adapter: Either 'chatDetails' or 'startChatEndpoint' must be provided.",
-      );
-    }
-
-    const body: Record<string, unknown> = {};
-    if (config.startChatParams?.instanceId != null) {
-      body.InstanceId = config.startChatParams.instanceId;
-    }
-    if (config.startChatParams?.contactFlowId != null) {
-      body.ContactFlowId = config.startChatParams.contactFlowId;
-    }
-    if (config.startChatParams?.participantDisplayName != null) {
-      body.ParticipantDetails = {
-        DisplayName: config.startChatParams.participantDisplayName,
-      };
-    }
-    if (config.startChatParams?.contactAttributes != null) {
-      body.Attributes = config.startChatParams.contactAttributes;
-    }
-
-    body.SupportedMessagingContentTypes = config.startChatParams
-      ?.supportedMessagingContentTypes ?? [
-      "text/plain",
-      "text/markdown",
-      "application/json",
-      "application/vnd.amazonaws.connect.message.interactive",
-    ];
-
-    const res = await fetch(config.startChatEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      throw new Error(`StartChatContact endpoint returned ${res.status}`);
-    }
-
-    const data = await res.json();
-    // The CloudFormation-deployed Lambda returns: { data: { startChatResult: { ContactId, ParticipantId, ParticipantToken } } }
-    const startChatResult = data?.data?.startChatResult ?? data?.data ?? data;
-    return {
-      contactId: startChatResult.ContactId ?? startChatResult.contactId,
-      participantId:
-        startChatResult.ParticipantId ?? startChatResult.participantId,
-      participantToken:
-        startChatResult.ParticipantToken ?? startChatResult.participantToken,
-    };
-  };
-
   let resolvedContactId: string | undefined;
 
   const initSession = async (): Promise<void> => {
-    const chatDetails = await fetchChatDetails();
-    resolvedContactId = chatDetails.contactId;
+    resolvedContactId = config.details.contactId;
 
     const connectGlobal = getConnectGlobal();
 
@@ -254,7 +219,7 @@ export function createConnectChatConversation(
     });
 
     chatSession = connectGlobal.ChatSession.create({
-      chatDetails,
+      chatDetails: config.details,
       type: connectGlobal.ChatSession.SessionTypes.CUSTOMER,
     });
 
@@ -268,7 +233,7 @@ export function createConnectChatConversation(
       const contentType: string = data.ContentType ?? "";
 
       if (contentType === "text/plain" || contentType === "text/markdown") {
-        const text = data.Content ?? "";
+        const text: string = data.Content ?? "";
         if (text.startsWith("{") && text.includes('"modalities"')) {
           handleJsonMessage(text);
         } else {
@@ -551,8 +516,8 @@ export function createConnectChatConversation(
         ...newResponse,
         receivedAt: (newResponse as any).receivedAt ?? Date.now(),
       };
-      responses = [...responses, responseWithTimestamp as Response];
-      notify(responseWithTimestamp as Response);
+      responses = [...responses, responseWithTimestamp];
+      notify(responseWithTimestamp);
     },
 
     subscribe,
@@ -632,4 +597,4 @@ export function createConnectChatConversation(
   };
 
   return handler;
-}
+};

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -14,6 +14,7 @@ import type {
   LanguageCode,
 } from "@nlxai/core";
 import { ResponseType } from "@nlxai/core";
+import "amazon-connect-chatjs";
 
 /**
  * Configuration for the Amazon Connect Chat adapter.
@@ -110,6 +111,12 @@ export const fetchChatDetails = async (
   };
 };
 
+const warnMethod = (methodName: string): void => {
+  console.warn(
+    `Message not sent: the '${methodName}' method is not supported by the Amazon Connect Chat Interface integration.`,
+  );
+};
+
 /**
  * Creates a ConversationHandler backed by Amazon Connect Chat via amazon-connect-chatjs.
  *
@@ -158,11 +165,13 @@ export const fetchChatDetails = async (
 export const createConnectChatConversation = (
   config: ConnectChatConfig,
 ): ConversationHandler => {
+  const connect = (window as any).connect;
+
   let subscribers: Subscriber[] = [];
   let responses: Response[] = [];
   let languageCode: LanguageCode = config.languageCode ?? "en-US";
   let requestOverride: RequestOverride | undefined;
-  let chatSession: any;
+  let chatSession: ReturnType<typeof connect.ChatSession.create> | null = null;
   let connected = false;
 
   const eventListeners: Record<
@@ -189,38 +198,19 @@ export const createConnectChatConversation = (
     notify(response);
   };
 
-  const getConnectGlobal = (): any => {
-    const g =
-      typeof globalThis !== "undefined"
-        ? globalThis
-        : typeof window !== "undefined"
-          ? window
-          : undefined;
-    const connectObj = (g as any)?.connect;
-    if (connectObj?.ChatSession == null) {
-      throw new Error(
-        "@nlxai/connect-chat-adapter: amazon-connect-chatjs must be loaded before creating a Connect Chat conversation. " +
-          "Import it via `import 'amazon-connect-chatjs'` or include the script tag.",
-      );
-    }
-    return connectObj;
-  };
-
   let resolvedContactId: string | undefined;
 
   const initSession = async (): Promise<void> => {
     resolvedContactId = config.details.contactId;
 
-    const connectGlobal = getConnectGlobal();
-
-    connectGlobal.ChatSession.setGlobalConfig({
+    connect.ChatSession.setGlobalConfig({
       region: config.region ?? "us-west-2",
       ...(config.globalConfig ?? {}),
     });
 
-    chatSession = connectGlobal.ChatSession.create({
+    chatSession = connect.ChatSession.create({
       chatDetails: config.details,
-      type: connectGlobal.ChatSession.SessionTypes.CUSTOMER,
+      type: connect.ChatSession.SessionTypes.CUSTOMER,
     });
 
     chatSession.onMessage((event: any) => {
@@ -274,7 +264,7 @@ export const createConnectChatConversation = (
       connected = false;
     });
 
-    await chatSession.connect();
+    await chatSession.connect(null);
   };
 
   const handleJsonMessage = (content: string | undefined): void => {
@@ -465,27 +455,27 @@ export const createConnectChatConversation = (
     sendChoice,
 
     sendSlots: (_slots: SlotsRecordOrArray, _context?: Context): void => {
-      // No-op: Connect Chat does not have a slots concept
+      warnMethod("sendSlots");
     },
 
     sendWelcomeFlow: (_context?: Context): void => {
-      // Connect Chat triggers the contact flow automatically on connection
+      warnMethod("sendWelcomeFlow");
     },
 
     sendWelcomeIntent: (_context?: Context): void => {
-      // Deprecated, no-op
+      warnMethod("sendWelcomeIntent");
     },
 
     sendFlow: (_flowId: string, _context?: Context): void => {
-      // No-op: Connect Chat does not support arbitrary flow triggering from client
+      warnMethod("sendFlow");
     },
 
     sendIntent: (_intentId: string, _context?: Context): void => {
-      // Deprecated, no-op
+      warnMethod("sendIntent");
     },
 
     sendContext: async (_context: Context): Promise<void> => {
-      // No-op
+      warnMethod("sendContext");
     },
 
     sendStructured: (
@@ -498,7 +488,7 @@ export const createConnectChatConversation = (
     },
 
     sendVoicePlusContext: (_context: VoicePlusContext): void => {
-      // No-op
+      warnMethod("sendVoicePlusContext");
     },
 
     getVoiceCredentials: async (): Promise<VoiceCredentials> => {
@@ -508,7 +498,7 @@ export const createConnectChatConversation = (
     },
 
     submitFeedback: async (): Promise<void> => {
-      // No-op
+      warnMethod("submitFeedback");
     },
 
     appendMessageToTranscript: (newResponse): void => {
@@ -543,7 +533,7 @@ export const createConnectChatConversation = (
       // Disconnect old session and start a fresh Connect Chat session
       if (chatSession != null && connected) {
         try {
-          chatSession.disconnectParticipant();
+          (chatSession as any).disconnectParticipant();
         } catch (_e) {
           /* best effort */
         }
@@ -565,7 +555,7 @@ export const createConnectChatConversation = (
     destroy: (): void => {
       subscribers = [];
       if (chatSession != null && connected) {
-        chatSession.disconnectParticipant();
+        (chatSession as any).disconnectParticipant();
       }
     },
 

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -266,7 +266,7 @@ export const createConnectChatConversation = (
       connected = false;
     });
 
-    await chatSession.connect(null);
+    await chatSession.connect();
   };
 
   const handleJsonMessage = (content: string | undefined): void => {

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -133,17 +133,9 @@ interface ResolvedChatDetails {
  * });
  * ```
  */
-export interface ConnectChatConversationHandler extends ConversationHandler {
-  /**
-   * Emit a custom interim message to display in Touchpoint's loading state.
-   * Pass `undefined` to clear it.
-   */
-  emitInterimMessage: (message?: string) => void;
-}
-
 export function createConnectChatConversation(
   config: ConnectChatConfig,
-): ConnectChatConversationHandler {
+): ConversationHandler {
   let subscribers: Subscriber[] = [];
   let responses: Response[] = [];
   let languageCode: LanguageCode = config.languageCode ?? "en-US";
@@ -151,7 +143,10 @@ export function createConnectChatConversation(
   let chatSession: any;
   let connected = false;
 
-  const eventListeners: Record<ConversationHandlerEvent, Array<(...args: any[]) => void>> = {
+  const eventListeners: Record<
+    ConversationHandlerEvent,
+    Array<(...args: any[]) => void>
+  > = {
     interimMessage: [],
     voicePlusCommand: [],
   };
@@ -164,19 +159,26 @@ export function createConnectChatConversation(
 
   const appendResponse = (response: Response): void => {
     if (response.type === ResponseType.Application) {
-      eventListeners.interimMessage.forEach((listener) => (listener as any)(undefined));
+      eventListeners.interimMessage.forEach((listener) =>
+        (listener as any)(undefined),
+      );
     }
     responses = [...responses, response];
     notify(response);
   };
 
   const getConnectGlobal = (): any => {
-    const g = typeof globalThis !== "undefined" ? globalThis : typeof window !== "undefined" ? window : undefined;
+    const g =
+      typeof globalThis !== "undefined"
+        ? globalThis
+        : typeof window !== "undefined"
+          ? window
+          : undefined;
     const connectObj = (g as any)?.connect;
     if (connectObj?.ChatSession == null) {
       throw new Error(
         "@nlxai/connect-chat-adapter: amazon-connect-chatjs must be loaded before creating a Connect Chat conversation. " +
-        "Import it via `import 'amazon-connect-chatjs'` or include the script tag.",
+          "Import it via `import 'amazon-connect-chatjs'` or include the script tag.",
       );
     }
     return connectObj;
@@ -208,13 +210,13 @@ export function createConnectChatConversation(
       body.Attributes = config.startChatParams.contactAttributes;
     }
 
-    body.SupportedMessagingContentTypes =
-      config.startChatParams?.supportedMessagingContentTypes ?? [
-        "text/plain",
-        "text/markdown",
-        "application/json",
-        "application/vnd.amazonaws.connect.message.interactive",
-      ];
+    body.SupportedMessagingContentTypes = config.startChatParams
+      ?.supportedMessagingContentTypes ?? [
+      "text/plain",
+      "text/markdown",
+      "application/json",
+      "application/vnd.amazonaws.connect.message.interactive",
+    ];
 
     const res = await fetch(config.startChatEndpoint, {
       method: "POST",
@@ -231,8 +233,10 @@ export function createConnectChatConversation(
     const startChatResult = data?.data?.startChatResult ?? data?.data ?? data;
     return {
       contactId: startChatResult.ContactId ?? startChatResult.contactId,
-      participantId: startChatResult.ParticipantId ?? startChatResult.participantId,
-      participantToken: startChatResult.ParticipantToken ?? startChatResult.participantToken,
+      participantId:
+        startChatResult.ParticipantId ?? startChatResult.participantId,
+      participantToken:
+        startChatResult.ParticipantToken ?? startChatResult.participantToken,
     };
   };
 
@@ -263,10 +267,7 @@ export function createConnectChatConversation(
 
       const contentType: string = data.ContentType ?? "";
 
-      if (
-        contentType === "text/plain" ||
-        contentType === "text/markdown"
-      ) {
+      if (contentType === "text/plain" || contentType === "text/markdown") {
         const text = data.Content ?? "";
         if (text.startsWith("{") && text.includes('"modalities"')) {
           handleJsonMessage(text);
@@ -284,7 +285,9 @@ export function createConnectChatConversation(
         }
       } else if (contentType === "application/json") {
         handleJsonMessage(data.Content);
-      } else if (contentType === "application/vnd.amazonaws.connect.message.interactive") {
+      } else if (
+        contentType === "application/vnd.amazonaws.connect.message.interactive"
+      ) {
         handleInteractiveMessage(data.Content);
       }
     });
@@ -314,14 +317,18 @@ export function createConnectChatConversation(
     try {
       const parsed = JSON.parse(content);
 
-      const messages: Array<{ text: string; choices: Array<{ choiceId: string; choiceText: string }> }> = [];
+      const messages: Array<{
+        text: string;
+        choices: Array<{ choiceId: string; choiceText: string }>;
+      }> = [];
 
       if (Array.isArray(parsed.messages) && parsed.messages.length > 0) {
         for (const msg of parsed.messages) {
           const choices = Array.isArray(msg.choices)
             ? msg.choices.map((c: any, i: number) => ({
                 choiceId: c.choiceId ?? c.id ?? `choice-${i}`,
-                choiceText: c.choiceText ?? c.text ?? c.label ?? `Option ${i + 1}`,
+                choiceText:
+                  c.choiceText ?? c.text ?? c.label ?? `Option ${i + 1}`,
               }))
             : [];
           messages.push({ text: msg.text ?? "", choices });
@@ -422,7 +429,9 @@ export function createConnectChatConversation(
     appendResponse({
       type: ResponseType.Failure,
       receivedAt: Date.now(),
-      payload: { text: `Failed to connect: ${err instanceof Error ? err.message : "Unknown error"}` },
+      payload: {
+        text: `Failed to connect: ${err instanceof Error ? err.message : "Unknown error"}`,
+      },
     });
   });
 
@@ -486,7 +495,7 @@ export function createConnectChatConversation(
     subscribers = subscribers.filter((fn) => fn !== subscriber);
   };
 
-  const handler: ConnectChatConversationHandler = {
+  const handler: ConversationHandler = {
     sendText,
     sendChoice,
 
@@ -514,7 +523,10 @@ export function createConnectChatConversation(
       // No-op
     },
 
-    sendStructured: (structured: StructuredRequest, _context?: Context): void => {
+    sendStructured: (
+      structured: StructuredRequest,
+      _context?: Context,
+    ): void => {
       if (structured.utterance != null) {
         sendText(structured.utterance);
       }
@@ -525,7 +537,9 @@ export function createConnectChatConversation(
     },
 
     getVoiceCredentials: async (): Promise<VoiceCredentials> => {
-      throw new Error("Voice credentials are not supported by the Connect Chat adapter.");
+      throw new Error(
+        "Voice credentials are not supported by the Connect Chat adapter.",
+      );
     },
 
     submitFeedback: async (): Promise<void> => {
@@ -563,7 +577,11 @@ export function createConnectChatConversation(
       notify();
       // Disconnect old session and start a fresh Connect Chat session
       if (chatSession != null && connected) {
-        try { chatSession.disconnectParticipant(); } catch (_e) { /* best effort */ }
+        try {
+          chatSession.disconnectParticipant();
+        } catch (_e) {
+          /* best effort */
+        }
       }
       connected = false;
       chatSession = null;
@@ -572,7 +590,9 @@ export function createConnectChatConversation(
         appendResponse({
           type: ResponseType.Failure,
           receivedAt: Date.now(),
-          payload: { text: `Failed to reconnect: ${err instanceof Error ? err.message : "Unknown error"}` },
+          payload: {
+            text: `Failed to reconnect: ${err instanceof Error ? err.message : "Unknown error"}`,
+          },
         });
       });
     },
@@ -599,11 +619,15 @@ export function createConnectChatConversation(
       event: ConversationHandlerEvent,
       handler: EventHandlers[ConversationHandlerEvent],
     ): void => {
-      eventListeners[event] = eventListeners[event].filter((h) => h !== handler);
+      eventListeners[event] = eventListeners[event].filter(
+        (h) => h !== handler,
+      );
     },
 
-    emitInterimMessage: (message?: string): void => {
-      eventListeners.interimMessage.forEach((listener) => (listener as any)(message));
+    setInterimMessage: (message?: string): void => {
+      eventListeners.interimMessage.forEach((listener) =>
+        (listener as any)(message),
+      );
     },
   };
 

--- a/packages/connect-chat-adapter/src/index.ts
+++ b/packages/connect-chat-adapter/src/index.ts
@@ -119,41 +119,25 @@ const warnMethod = (methodName: string): void => {
   );
 };
 
+type ConversationHandlerEventListeners = Record<
+  ConversationHandlerEvent,
+  Array<EventHandlers[ConversationHandlerEvent]>
+>;
+
 /**
  * Creates a ConversationHandler backed by Amazon Connect Chat via amazon-connect-chatjs.
  *
  * This adapter conforms to the same interface used by \@nlxai/core's `createConversation`,
  * so it can be passed directly to Touchpoint UI via the `conversationHandler` prop.
  *
- * Prerequisites:
- * - `amazon-connect-chatjs` must be loaded before calling this function
- * (via `import "amazon-connect-chatjs"` or a `<script>` tag).
- * - Either provide a `startChatEndpoint` (URL of the API Gateway from the AWS
- * CloudFormation template) or pre-obtained `chatDetails`.
  * @example
  * ```typescript
- * import "amazon-connect-chatjs";
  * import { createConnectChatConversation } from "@nlxai/connect-chat-adapter";
  * import { create } from "@nlxai/touchpoint-ui";
  *
- * // Option 1: Let the adapter call StartChatContact via your API Gateway
  * const touchpoint = await create({
  *   conversationHandler: createConnectChatConversation({
- *     startChatEndpoint: "https://abc123.execute-api.us-east-1.amazonaws.com/Prod",
- *     startChatParams: {
- *       instanceId: "your-connect-instance-id",
- *       contactFlowId: "your-contact-flow-id",
- *       participantDisplayName: "Customer",
- *     },
- *     region: "us-east-1",
- *   }),
- *   theme: { accent: "#0972d3" },
- * });
- *
- * // Option 2: Pass pre-obtained chatDetails
- * const touchpoint = await create({
- *   conversationHandler: createConnectChatConversation({
- *     chatDetails: {
+ *     details: {
  *       contactId: "abc-123",
  *       participantId: "def-456",
  *       participantToken: "token-xyz",
@@ -176,10 +160,7 @@ export const createConnectChatConversation = (
   let chatSession: ReturnType<typeof connect.ChatSession.create> | null = null;
   let connected = false;
 
-  const eventListeners: Record<
-    ConversationHandlerEvent,
-    Array<(...args: any[]) => void>
-  > = {
+  const eventListeners: ConversationHandlerEventListeners = {
     interimMessage: [],
     voicePlusCommand: [],
   };
@@ -311,6 +292,7 @@ export const createConnectChatConversation = (
           ...(modalities != null ? { modalities } : {}),
         },
       };
+
       appendResponse(newResponse);
     } catch (_err) {
       appendResponse({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -265,6 +265,11 @@ export interface ConversationHandler {
    * @internal
    */
   sendVoicePlusContext: (context: VoicePlusContext) => void;
+  /**
+   * Set interim message. Setting `undefined` clears the current interim message.
+   * @param message - interim message.
+   */
+  setInterimMessage: (message?: string) => void;
 }
 
 /**
@@ -1245,11 +1250,11 @@ export function createConversation(configuration: Config): ConversationHandler {
   const websocketApplicationUrl =
     connection != null
       ? toWebsocketUrl(connection)
-      : configuration.applicationUrl ?? "";
+      : (configuration.applicationUrl ?? "");
   const httpApplicationUrl =
     connection != null
       ? toHttpUrl(connection)
-      : configuration.applicationUrl ?? "";
+      : (configuration.applicationUrl ?? "");
 
   // Check if the application URL has a language code appended to it
   if (/[-|_][a-z]{2,}[-|_][A-Z]{2,}$/.test(httpApplicationUrl)) {
@@ -1358,6 +1363,14 @@ export function createConversation(configuration: Config): ConversationHandler {
     } else {
       voicePlusSocketMessageQueue = [...voicePlusSocketMessageQueue, message];
     }
+  };
+
+  const setInterimMessage = (message?: string) => {
+    eventListeners.interimMessage.forEach(
+      (listener: InterimMessageListener) => {
+        listener(message);
+      },
+    );
   };
 
   const sendToApplication = async (
@@ -1691,6 +1704,7 @@ export function createConversation(configuration: Config): ConversationHandler {
         newResponseWithTimestamp,
       );
     },
+    setInterimMessage,
     sendStructured: (structured: StructuredRequest, context) => {
       appendStructuredUserResponse(structured, context);
       void sendToApplication({

--- a/packages/touchpoint-ui/connect-chat.html
+++ b/packages/touchpoint-ui/connect-chat.html
@@ -166,8 +166,6 @@
             participantDisplayName: displayName,
           });
 
-          console.log(details);
-
           const conversationHandler = createConnectChatConversation({
             details,
             region,

--- a/packages/touchpoint-ui/connect-chat.html
+++ b/packages/touchpoint-ui/connect-chat.html
@@ -128,7 +128,6 @@
 
     <nlx-touchpoint id="touchpoint" style="display: none"></nlx-touchpoint>
 
-    <script src="https://cdn.jsdelivr.net/npm/amazon-connect-chatjs@2/dist/amazon-connect-chat.js"></script>
     <script type="module">
       import { create } from "./src/index.tsx";
 
@@ -161,11 +160,13 @@
           const { createConnectChatConversation, fetchChatDetails } =
             await import("../../packages/connect-chat-adapter/src/index.ts");
 
-          const details = fetchChatDetails(endpoint, {
+          const details = await fetchChatDetails(endpoint, {
             instanceId,
             contactFlowId,
             participantDisplayName: displayName,
           });
+
+          console.log(details);
 
           const conversationHandler = createConnectChatConversation({
             details,

--- a/packages/touchpoint-ui/connect-chat.html
+++ b/packages/touchpoint-ui/connect-chat.html
@@ -158,16 +158,17 @@
           tpEl.style.height = "100%";
 
           // Import the adapter — it's in the sibling package
-          const { createConnectChatConversation } =
+          const { createConnectChatConversation, fetchChatDetails } =
             await import("../../packages/connect-chat-adapter/src/index.ts");
 
+          const details = fetchChatDetails(endpoint, {
+            instanceId,
+            contactFlowId,
+            participantDisplayName: displayName,
+          });
+
           const conversationHandler = createConnectChatConversation({
-            startChatEndpoint: endpoint,
-            startChatParams: {
-              instanceId,
-              contactFlowId,
-              participantDisplayName: displayName,
-            },
+            details,
             region,
           });
 

--- a/packages/touchpoint-ui/connect-chat.html
+++ b/packages/touchpoint-ui/connect-chat.html
@@ -10,6 +10,7 @@
         margin: 0;
         padding: 0;
       }
+
       .config-form {
         font-family:
           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -20,16 +21,19 @@
         border-radius: 12px;
         color: #e0e0e0;
       }
+
       .config-form h1 {
         font-size: 20px;
         margin: 0 0 8px;
         color: #fff;
       }
+
       .config-form p {
         font-size: 13px;
         color: #999;
         margin: 0 0 24px;
       }
+
       .config-form label {
         display: block;
         font-size: 12px;
@@ -37,6 +41,7 @@
         margin-bottom: 4px;
         color: #aaa;
       }
+
       .config-form input {
         width: 100%;
         padding: 8px 12px;
@@ -48,9 +53,11 @@
         font-size: 14px;
         box-sizing: border-box;
       }
+
       .config-form input::placeholder {
         color: #555;
       }
+
       .config-form button {
         width: 100%;
         padding: 12px;
@@ -62,6 +69,7 @@
         font-weight: 600;
         cursor: pointer;
       }
+
       .config-form button:hover {
         background: #0860b0;
       }
@@ -171,7 +179,7 @@
           });
 
           // Set custom loading text (instead of default "Thinking")
-          conversationHandler.emitInterimMessage("Connecting...");
+          conversationHandler.setInterimMessage("Connecting...");
 
           tpEl.touchpointConfiguration = {
             conversationHandler,

--- a/packages/touchpoint-ui/package.json
+++ b/packages/touchpoint-ui/package.json
@@ -11,6 +11,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "dev": "vite",
+    "dev:connect": "vite --open connect-chat.html",
     "design-system": "vite --mode design-system",
     "build:design-system": "vite build --mode design-system",
     "build": "tsc && vite build",

--- a/packages/touchpoint-ui/src/interface.ts
+++ b/packages/touchpoint-ui/src/interface.ts
@@ -3,7 +3,6 @@ import type {
   ApplicationMessage,
   ConversationHandler,
   Context,
-  LanguageCode,
 } from "@nlxai/core";
 import { type ComponentType } from "react";
 import type { InteractiveElementInfo } from "./bidirectional/analyzePageForms";

--- a/packages/touchpoint-ui/src/mocks/shared.ts
+++ b/packages/touchpoint-ui/src/mocks/shared.ts
@@ -42,6 +42,7 @@ export const mockConversationHandler: ConversationHandler = {
   addEventListener: () => {},
   removeEventListener: () => {},
   sendVoicePlusContext: () => {},
+  setInterimMessage: () => {},
 };
 
 export const responses: Response[] = [


### PR DESCRIPTION
- [x] Method to set interim message for all conversation handlers - no more need to specify a new conversation handler extension inside the connect package, all handlers just work the same.
- [x] Exports separate `fetchChatDetails(endpoint, params)` method that can be called right before creating the connect conversation, . This removes the need to type/specify mutually exclusive configuration, and allows the user more control on when the configurations are fetched.
- [x] Sets up a `npm run dev:connect` to run connect example directly.
- [x] Fixes lint issues and adds the package to lerna, preparing for publishing.