### PR TITLE
Remove duplicate build on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "lerna run lint",
     "postinstall": "npm run build",
     "publish": "lerna publish",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "publish-docs": "lerna run publish-docs",
     "gitbook-docs:update": "bash ./scripts/update-gitbook-developer-docs.sh",
     "test": "lerna run test",


### PR DESCRIPTION
Currently, `npm install` builds the packages twice. This should take
care of that, and use the recommended script name.
